### PR TITLE
Add cut-off marks importer and calculator

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,11 @@ php artisan migrate
 php artisan db:seed
 ```
 
+### 7.1 Importar notas de corte reales
+```bash
+php artisan import:cutoff-marks
+```
+
 ### 8. Configurar el almacenamiento
 ```bash
 php artisan storage:link

--- a/app/Console/Commands/ImportCutOffMarks.php
+++ b/app/Console/Commands/ImportCutOffMarks.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use App\Models\AcademicInfo;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+use DOMDocument;
+use DOMXPath;
+
+class ImportCutOffMarks extends Command
+{
+    protected $signature = 'import:cutoff-marks';
+
+    protected $description = 'Importar notas de corte desde notasdecorte.es';
+
+    public function handle(): int
+    {
+        $this->info('Iniciando importación de notas de corte...');
+
+        try {
+            $sitemap = 'https://notasdecorte.es/sitemap.xml';
+            $pages = [$sitemap];
+
+            $response = Http::get($sitemap);
+            if ($response->ok()) {
+                $xml = simplexml_load_string($response->body());
+                foreach ($xml->sitemap as $item) {
+                    $pages[] = (string) $item->loc;
+                }
+            }
+
+            foreach ($pages as $pageUrl) {
+                $this->info('Procesando '.$pageUrl);
+                $xmlResponse = Http::get($pageUrl);
+                if (!$xmlResponse->ok()) {
+                    continue;
+                }
+                $xml = simplexml_load_string($xmlResponse->body());
+                foreach ($xml->url as $url) {
+                    $this->scrapePage((string) $url->loc);
+                }
+            }
+
+            $this->info('Importación completada');
+            return Command::SUCCESS;
+        } catch (\Throwable $e) {
+            Log::error('Error al importar notas de corte: '.$e->getMessage());
+            $this->error('Error al importar notas de corte');
+            return Command::FAILURE;
+        }
+    }
+
+    private function scrapePage(string $url): void
+    {
+        $html = Http::get($url)->body();
+        $dom = new DOMDocument();
+        @$dom->loadHTML($html);
+        $xpath = new DOMXPath($dom);
+
+        $rows = $xpath->query('//table[contains(@class,"views-table")]/tbody/tr');
+        foreach ($rows as $row) {
+            $cells = $row->getElementsByTagName('td');
+            if ($cells->length < 4) {
+                continue;
+            }
+            $degree = trim($cells->item(0)->textContent);
+            $university = trim($cells->item(1)->textContent);
+            $city = trim($cells->item(2)->textContent);
+            $mark = floatval(str_replace(',', '.', trim($cells->item(3)->textContent)));
+
+            AcademicInfo::updateOrCreate(
+                [
+                    'university_name' => $university,
+                    'degree_name' => $degree,
+                    'year' => date('Y'),
+                    'type' => 'notas-corte',
+                ],
+                [
+                    'city' => $city,
+                    'cut_off_mark' => $mark,
+                ]
+            );
+        }
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Console;
+
+use Illuminate\Console\Application as Artisan;
+use Illuminate\Console\Scheduling\Schedule;
+use Illuminate\Foundation\Console\Kernel as ConsoleKernel;
+
+class Kernel extends ConsoleKernel
+{
+    protected function schedule(Schedule $schedule): void
+    {
+        //
+    }
+
+    protected function commands(): void
+    {
+        $this->load(__DIR__.'/Commands');
+    }
+}

--- a/app/Http/Controllers/AcademicInfoController.php
+++ b/app/Http/Controllers/AcademicInfoController.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\AcademicInfo;
+use Illuminate\Http\Request;
+use Illuminate\View\View;
+
+class AcademicInfoController extends Controller
+{
+    public function cutOffMarks(Request $request): View
+    {
+        $query = AcademicInfo::cutOffMarks();
+
+        if ($request->filled('city')) {
+            $query->byCity($request->input('city'));
+        }
+        if ($request->filled('min_mark')) {
+            $query->where('cut_off_mark', '>=', $request->input('min_mark'));
+        }
+        if ($request->filled('max_mark')) {
+            $query->where('cut_off_mark', '<=', $request->input('max_mark'));
+        }
+
+        $marks = $query->orderBy('cut_off_mark', 'asc')->paginate(20);
+        return view('academic.cut-off-marks', compact('marks'));
+    }
+
+    public function calculator(Request $request): View
+    {
+        $grade = $request->input('grade');
+        $city = $request->input('city');
+        $query = AcademicInfo::cutOffMarks();
+        if ($grade !== null) {
+            $query->withCutOffBelow($grade);
+        }
+        if ($city) {
+            $query->byCity($city);
+        }
+        $results = $query->orderBy('cut_off_mark')->get();
+        return view('academic.calculator', compact('results', 'grade', 'city'));
+    }
+}

--- a/app/Models/AcademicInfo.php
+++ b/app/Models/AcademicInfo.php
@@ -13,6 +13,7 @@ class AcademicInfo extends Model
 
     protected $fillable = [
         'university_name',
+        'city',
         'degree_name',
         'cut_off_mark',
         'year',
@@ -94,6 +95,14 @@ class AcademicInfo extends Model
     }
 
     /**
+     * Scope to filter by city.
+     */
+    public function scopeByCity($query, $city)
+    {
+        return $query->where('city', 'like', '%' . $city . '%');
+    }
+
+    /**
      * Scope to filter by type.
      */
     public function scopeByType($query, $type)
@@ -134,6 +143,14 @@ class AcademicInfo extends Model
     {
         return $query->where('type', 'notas-corte')
                     ->whereNotNull('cut_off_mark');
+    }
+
+    /**
+     * Scope to filter cut off marks below or equal to a value.
+     */
+    public function scopeWithCutOffBelow($query, $mark)
+    {
+        return $query->where('cut_off_mark', '<=', $mark);
     }
 
     /**

--- a/database/migrations/2025_06_04_add_city_to_academic_info_table.php
+++ b/database/migrations/2025_06_04_add_city_to_academic_info_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('academic_info', function (Blueprint $table) {
+            $table->string('city')->nullable()->after('university_name');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('academic_info', function (Blueprint $table) {
+            $table->dropColumn('city');
+        });
+    }
+};

--- a/resources/views/academic/calculator.blade.php
+++ b/resources/views/academic/calculator.blade.php
@@ -1,0 +1,42 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="container">
+    <h1 class="mb-4">Calculadora de notas de corte</h1>
+    <form method="GET" class="row g-2 mb-3">
+        <div class="col-md-3">
+            <input type="number" step="0.01" name="grade" value="{{ request('grade') }}" class="form-control" placeholder="Tu nota">
+        </div>
+        <div class="col-md-3">
+            <input type="text" name="city" value="{{ request('city') }}" class="form-control" placeholder="Ciudad opcional">
+        </div>
+        <div class="col-md-3">
+            <button class="btn btn-success w-100">Buscar</button>
+        </div>
+    </form>
+    @isset($results)
+    <table class="table table-bordered">
+        <thead>
+            <tr>
+                <th>Grado</th>
+                <th>Universidad</th>
+                <th>Ciudad</th>
+                <th>Nota de corte</th>
+            </tr>
+        </thead>
+        <tbody>
+            @forelse ($results as $info)
+            <tr>
+                <td>{{ $info->degree_name }}</td>
+                <td>{{ $info->university_name }}</td>
+                <td>{{ $info->city }}</td>
+                <td>{{ $info->cut_off_mark }}</td>
+            </tr>
+            @empty
+            <tr><td colspan="4" class="text-center">No hay resultados</td></tr>
+            @endforelse
+        </tbody>
+    </table>
+    @endisset
+</div>
+@endsection

--- a/resources/views/academic/cut-off-marks.blade.php
+++ b/resources/views/academic/cut-off-marks.blade.php
@@ -1,0 +1,42 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="container">
+    <h1 class="mb-4">Notas de corte</h1>
+    <form method="GET" class="row g-2 mb-3">
+        <div class="col-md-3">
+            <input type="text" name="city" value="{{ request('city') }}" class="form-control" placeholder="Ciudad">
+        </div>
+        <div class="col-md-3">
+            <input type="number" step="0.01" name="min_mark" value="{{ request('min_mark') }}" class="form-control" placeholder="Nota mínima">
+        </div>
+        <div class="col-md-3">
+            <input type="number" step="0.01" name="max_mark" value="{{ request('max_mark') }}" class="form-control" placeholder="Nota máxima">
+        </div>
+        <div class="col-md-3">
+            <button class="btn btn-primary w-100">Filtrar</button>
+        </div>
+    </form>
+    <table class="table table-bordered">
+        <thead>
+            <tr>
+                <th>Grado</th>
+                <th>Universidad</th>
+                <th>Ciudad</th>
+                <th>Nota de corte</th>
+            </tr>
+        </thead>
+        <tbody>
+            @foreach ($marks as $info)
+            <tr>
+                <td>{{ $info->degree_name }}</td>
+                <td>{{ $info->university_name }}</td>
+                <td>{{ $info->city }}</td>
+                <td>{{ $info->cut_off_mark }}</td>
+            </tr>
+            @endforeach
+        </tbody>
+    </table>
+    {{ $marks->withQueryString()->links() }}
+</div>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -81,6 +81,7 @@ Route::prefix('academic')->name('academic.')->group(function () {
     Route::get('/', [AcademicInfoController::class, 'index'])->name('index');
     Route::get('/scholarships', [AcademicInfoController::class, 'scholarships'])->name('scholarships');
     Route::get('/cut-off-marks', [AcademicInfoController::class, 'cutOffMarks'])->name('cut-off-marks');
+    Route::get('/cut-off-calculator', [AcademicInfoController::class, 'calculator'])->name('calculator');
     Route::get('/search', [AcademicInfoController::class, 'search'])->name('search');
     
     // Rutas protegidas para preferencias académicas


### PR DESCRIPTION
## Summary
- add migration to include city in academic info
- extend AcademicInfo model with city support and filtering scopes
- add command to scrape notesdecorte.es cut-off marks
- add AcademicInfoController with calculator
- add views for cut-off marks and calculator
- register calculator route
- document cut-off marks import command

## Testing
- `./vendor/bin/phpunit` *(fails: Test directory not found)*

------
https://chatgpt.com/codex/tasks/task_e_683ffa671ee88329a7a86e93e4af7305