### PR TITLE
Remove duplicate Auth routes

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -180,6 +180,5 @@ Route::get('/terms', function () {
 Route::fallback(function () {
     return view('errors.404');
 });
-Auth::routes();
 
 Route::get('/home', [App\Http\Controllers\HomeController::class, 'index'])->name('home');


### PR DESCRIPTION
## Summary
- remove duplicated `Auth::routes()` call and keep verified version

## Testing
- `php artisan test --stop-on-failure` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684005334d808329a0c0ee4e34e83f62