### PR TITLE
Add 500 error page

### DIFF
--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -3,6 +3,7 @@
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
+use Symfony\Component\HttpFoundation\Response;
 
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
@@ -20,5 +21,11 @@ return Application::configure(basePath: dirname(__DIR__))
         ]);
     })
     ->withExceptions(function (Exceptions $exceptions) {
-        //
+        $exceptions->respond(function (Response $response) {
+            if ($response->getStatusCode() >= 500) {
+                return response()->view('errors.500', status: 500);
+            }
+
+            return $response;
+        });
     })->create();

--- a/resources/views/errors/500.blade.php
+++ b/resources/views/errors/500.blade.php
@@ -1,0 +1,9 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="container py-5 text-center">
+    <h1 class="display-4">Error del servidor</h1>
+    <p class="lead">Ha ocurrido un problema inesperado.</p>
+    <a href="{{ url('/') }}" class="btn btn-primary mt-3">Volver al inicio</a>
+</div>
+@endsection


### PR DESCRIPTION
## Summary
- create `resources/views/errors/500.blade.php`
- display the 500 view for server errors via the exception handler

## Testing
- `vendor/bin/phpunit` *(fails: Test directory not found)*

------
https://chatgpt.com/codex/tasks/task_e_68400550e4f48329a4a45a8b103b4a54