### PR TITLE
Enforce image upload limits in listing requests

### DIFF
--- a/app/Http/Requests/StoreListingRequest.php
+++ b/app/Http/Requests/StoreListingRequest.php
@@ -21,6 +21,9 @@ class StoreListingRequest extends FormRequest
      */
     public function rules(): array
     {
+        $imageTypes = implode(',', config('services.upload_limits.allowed_image_types', ['jpg','jpeg','png','gif']));
+        $maxSize = config('services.upload_limits.max_image_size', 2048);
+
         return [
             'title' => 'required|string|max:255',
             'description' => 'required|string|max:2000',
@@ -39,7 +42,7 @@ class StoreListingRequest extends FormRequest
             'latitude' => 'nullable|numeric|between:-90,90',
             'longitude' => 'nullable|numeric|between:-180,180',
             'images' => 'nullable|array|max:5',
-            'images.*' => 'image|mimes:jpeg,png,jpg,gif|max:2048',
+            'images.*' => "image|mimes:$imageTypes|max:$maxSize",
         ];
     }
 
@@ -74,6 +77,9 @@ class StoreListingRequest extends FormRequest
      */
     public function messages(): array
     {
+        $imageTypesText = implode(', ', config('services.upload_limits.allowed_image_types', ['jpg', 'jpeg', 'png', 'gif']));
+        $maxSizeMB = (int) (config('services.upload_limits.max_image_size', 2048) / 1024);
+
         return [
             'title.required' => 'El título es obligatorio.',
             'title.max' => 'El título no puede exceder los 255 caracteres.',
@@ -98,8 +104,8 @@ class StoreListingRequest extends FormRequest
             'images.array' => 'Las imágenes deben enviarse como un array.',
             'images.max' => 'No puedes subir más de 5 imágenes.',
             'images.*.image' => 'Cada archivo debe ser una imagen válida.',
-            'images.*.mimes' => 'Las imágenes deben ser de tipo: jpeg, png, jpg o gif.',
-            'images.*.max' => 'Cada imagen no puede exceder los 2MB.',
+            'images.*.mimes' => "Las imágenes deben ser de tipo: {$imageTypesText}.",
+            'images.*.max' => "Cada imagen no puede exceder los {$maxSizeMB}MB.",
         ];
     }
 }

--- a/app/Http/Requests/UpdateListingRequest.php
+++ b/app/Http/Requests/UpdateListingRequest.php
@@ -21,6 +21,9 @@ class UpdateListingRequest extends FormRequest
      */
     public function rules(): array
     {
+        $imageTypes = implode(',', config('services.upload_limits.allowed_image_types', ['jpg','jpeg','png','gif']));
+        $maxSize = config('services.upload_limits.max_image_size', 2048);
+
         return [
             'title' => 'required|string|max:255',
             'description' => 'required|string|max:2000',
@@ -40,7 +43,7 @@ class UpdateListingRequest extends FormRequest
             'latitude' => 'nullable|numeric|between:-90,90',
             'longitude' => 'nullable|numeric|between:-180,180',
             'images' => 'nullable|array|max:5',
-            'images.*' => 'image|mimes:jpeg,png,jpg,gif|max:2048',
+            'images.*' => "image|mimes:$imageTypes|max:$maxSize",
         ];
     }
 
@@ -76,6 +79,9 @@ class UpdateListingRequest extends FormRequest
      */
     public function messages(): array
     {
+        $imageTypesText = implode(', ', config('services.upload_limits.allowed_image_types', ['jpg', 'jpeg', 'png', 'gif']));
+        $maxSizeMB = (int) (config('services.upload_limits.max_image_size', 2048) / 1024);
+
         return [
             'title.required' => 'El título es obligatorio.',
             'title.max' => 'El título no puede exceder los 255 caracteres.',
@@ -100,8 +106,8 @@ class UpdateListingRequest extends FormRequest
             'images.array' => 'Las imágenes deben enviarse como un array.',
             'images.max' => 'No puedes subir más de 5 imágenes.',
             'images.*.image' => 'Cada archivo debe ser una imagen válida.',
-            'images.*.mimes' => 'Las imágenes deben ser de tipo: jpeg, png, jpg o gif.',
-            'images.*.max' => 'Cada imagen no puede exceder los 2MB.',
+            'images.*.mimes' => "Las imágenes deben ser de tipo: {$imageTypesText}.",
+            'images.*.max' => "Cada imagen no puede exceder los {$maxSizeMB}MB.",
         ];
     }
 }


### PR DESCRIPTION
## Summary
- add configurable image mime and size limits for listings
- update validation messages accordingly

## Testing
- `composer install` *(fails: command not found)*
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68400567854083298e888d5840464cfa