### PR TITLE
Add basic API routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,14 @@ php artisan test --coverage
 - `POST /events` - Crear evento
 - `GET /events/{id}` - Ver detalle
 
+### API JSON
+- `GET /api/listings` - Listar alojamientos en formato JSON
+- `GET /api/listings/{id}` - Detalle de un alojamiento
+- `GET /api/events` - Listar eventos en formato JSON
+- `GET /api/events/{id}` - Detalle de un evento
+- `GET /api/places` - Listar lugares
+- `GET /api/places/{id}` - Detalle de un lugar
+
 ### RoomieMatch
 - `GET /roomie-match/discover` - Descubrir potenciales compañeros
 - `POST /roomie-match/like/{user}` - Dar like a usuario

--- a/app/Services/PlaceService.php
+++ b/app/Services/PlaceService.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Place;
+use Illuminate\Database\Eloquent\Collection;
+
+class PlaceService
+{
+    public function getAllPlaces(): Collection
+    {
+        return Place::all();
+    }
+
+    public function findPlace(int $id): ?Place
+    {
+        return Place::find($id);
+    }
+
+    public function searchPlaces(array $filters): Collection
+    {
+        $query = Place::query();
+
+        $query->when(isset($filters['city']), function ($q) use ($filters) {
+            $q->inCity($filters['city']);
+        });
+
+        $query->when(isset($filters['category']), function ($q) use ($filters) {
+            $q->byCategory($filters['category']);
+        });
+
+        $query->when(isset($filters['search']), function ($q) use ($filters) {
+            $q->search($filters['search']);
+        });
+
+        return $query->get();
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -7,6 +7,7 @@ use Illuminate\Foundation\Configuration\Middleware;
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
         web: __DIR__.'/../routes/web.php',
+        api: __DIR__.'/../routes/api.php',
         commands: __DIR__.'/../routes/console.php',
         health: '/up',
     )

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,0 +1,67 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+use Illuminate\Http\Request;
+use App\Services\ListingService;
+use App\Services\EventService;
+use App\Services\PlaceService;
+
+Route::get('/listings', function (Request $request, ListingService $service) {
+    $filters = $request->only([
+        'city', 'type', 'min_price', 'max_price',
+        'bedrooms', 'bathrooms', 'available_from',
+        'search', 'university', 'radius'
+    ]);
+
+    $listings = !empty(array_filter($filters))
+        ? $service->searchListings($filters)
+        : $service->getPaginatedListings();
+
+    return response()->json($listings);
+});
+
+Route::get('/listings/{id}', function (int $id, ListingService $service) {
+    $listing = $service->findListing($id);
+
+    return $listing
+        ? response()->json($listing)
+        : response()->json(['message' => 'Listing not found'], 404);
+});
+
+Route::get('/events', function (Request $request, EventService $service) {
+    $filters = $request->only([
+        'category', 'date', 'start_date', 'end_date',
+        'city', 'free', 'available_spots', 'search'
+    ]);
+
+    $events = !empty(array_filter($filters))
+        ? $service->searchEvents($filters)
+        : $service->getPaginatedEvents();
+
+    return response()->json($events);
+});
+
+Route::get('/events/{id}', function (int $id, EventService $service) {
+    $event = $service->findEvent($id);
+
+    return $event
+        ? response()->json($event)
+        : response()->json(['message' => 'Event not found'], 404);
+});
+
+Route::get('/places', function (Request $request, PlaceService $service) {
+    $filters = $request->only(['city', 'category', 'search']);
+    $places = !empty(array_filter($filters))
+        ? $service->searchPlaces($filters)
+        : $service->getAllPlaces();
+
+    return response()->json($places);
+});
+
+Route::get('/places/{id}', function (int $id, PlaceService $service) {
+    $place = $service->findPlace($id);
+
+    return $place
+        ? response()->json($place)
+        : response()->json(['message' => 'Place not found'], 404);
+});


### PR DESCRIPTION
## Summary
- expose JSON endpoints for listings, events and places
- load api routes at bootstrap
- document new JSON routes
- add simple `PlaceService`

## Testing
- `composer --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840057e44648329991172dd4fb86197