### PR TITLE
Add ProfileController and editing views

### DIFF
--- a/app/Http/Controllers/ProfileController.php
+++ b/app/Http/Controllers/ProfileController.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Storage;
+use App\Models\Profile;
+
+class ProfileController extends Controller
+{
+    public function __construct()
+    {
+        $this->middleware(['auth', 'verified']);
+    }
+
+    public function show()
+    {
+        $profile = auth()->user()->profile;
+        return view('profile.show', compact('profile'));
+    }
+
+    public function edit()
+    {
+        $profile = auth()->user()->profile;
+        return view('profile.edit', compact('profile'));
+    }
+
+    public function update(Request $request)
+    {
+        $profile = auth()->user()->profile;
+
+        $data = $request->validate([
+            'bio' => ['nullable', 'string'],
+            'gender' => ['nullable', 'string'],
+            'age' => ['nullable', 'integer'],
+            'smoking_preference' => ['nullable', 'string'],
+            'pet_preference' => ['nullable', 'string'],
+            'cleanliness_level' => ['nullable', 'integer', 'min:1', 'max:5'],
+            'sleep_schedule' => ['nullable', 'string'],
+            'hobbies' => ['nullable', 'string'],
+            'academic_year' => ['nullable', 'string'],
+            'major' => ['nullable', 'string'],
+            'university_name' => ['nullable', 'string'],
+            'looking_for_roommate' => ['nullable', 'boolean'],
+            'profile_image' => ['nullable', 'image'],
+        ]);
+
+        $data['looking_for_roommate'] = $request->has('looking_for_roommate');
+
+        if (isset($data['hobbies'])) {
+            $data['hobbies'] = array_map('trim', explode(',', $data['hobbies']));
+        }
+
+        if ($request->hasFile('profile_image')) {
+            $path = $request->file('profile_image')->store('profiles', 'public');
+            $data['profile_image'] = $path;
+        } else {
+            unset($data['profile_image']);
+        }
+
+        $profile->update($data);
+
+        return redirect()->route('profile.show')->with('success', 'Perfil actualizado.');
+    }
+
+    public function destroy()
+    {
+        $profile = auth()->user()->profile;
+        if ($profile) {
+            $profile->delete();
+        }
+        return redirect()->route('home')->with('success', 'Perfil eliminado.');
+    }
+}
+

--- a/resources/views/profile/edit.blade.php
+++ b/resources/views/profile/edit.blade.php
@@ -1,0 +1,86 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="container">
+    <h1 class="mb-4">Editar Perfil</h1>
+    <form method="POST" action="{{ route('profile.update') }}" enctype="multipart/form-data">
+        @csrf
+        @method('PATCH')
+        <div class="mb-3">
+            <label class="form-label">Biografía</label>
+            <textarea name="bio" class="form-control">{{ old('bio', $profile->bio) }}</textarea>
+        </div>
+        <div class="mb-3">
+            <label class="form-label">Género</label>
+            <select name="gender" class="form-select">
+                <option value="">Selecciona una opción</option>
+                <option value="masculino" {{ old('gender', $profile->gender) == 'masculino' ? 'selected' : '' }}>Masculino</option>
+                <option value="femenino" {{ old('gender', $profile->gender) == 'femenino' ? 'selected' : '' }}>Femenino</option>
+                <option value="no-binario" {{ old('gender', $profile->gender) == 'no-binario' ? 'selected' : '' }}>No binario</option>
+                <option value="prefiero-no-decir" {{ old('gender', $profile->gender) == 'prefiero-no-decir' ? 'selected' : '' }}>Prefiero no decir</option>
+            </select>
+        </div>
+        <div class="mb-3">
+            <label class="form-label">Edad</label>
+            <input type="number" name="age" class="form-control" value="{{ old('age', $profile->age) }}">
+        </div>
+        <div class="mb-3">
+            <label class="form-label">Preferencia de fumar</label>
+            <select name="smoking_preference" class="form-select">
+                <option value="">Selecciona una opción</option>
+                <option value="fumador" {{ old('smoking_preference', $profile->smoking_preference) == 'fumador' ? 'selected' : '' }}>Fumador</option>
+                <option value="no-fumador" {{ old('smoking_preference', $profile->smoking_preference) == 'no-fumador' ? 'selected' : '' }}>No fumador</option>
+                <option value="flexible" {{ old('smoking_preference', $profile->smoking_preference) == 'flexible' ? 'selected' : '' }}>Flexible</option>
+            </select>
+        </div>
+        <div class="mb-3">
+            <label class="form-label">Preferencia de mascotas</label>
+            <select name="pet_preference" class="form-select">
+                <option value="">Selecciona una opción</option>
+                <option value="tiene-mascotas" {{ old('pet_preference', $profile->pet_preference) == 'tiene-mascotas' ? 'selected' : '' }}>Tiene mascotas</option>
+                <option value="le-gustan-mascotas" {{ old('pet_preference', $profile->pet_preference) == 'le-gustan-mascotas' ? 'selected' : '' }}>Le gustan las mascotas</option>
+                <option value="no-mascotas" {{ old('pet_preference', $profile->pet_preference) == 'no-mascotas' ? 'selected' : '' }}>No mascotas</option>
+                <option value="flexible" {{ old('pet_preference', $profile->pet_preference) == 'flexible' ? 'selected' : '' }}>Flexible</option>
+            </select>
+        </div>
+        <div class="mb-3">
+            <label class="form-label">Nivel de limpieza (1-5)</label>
+            <input type="number" name="cleanliness_level" min="1" max="5" class="form-control" value="{{ old('cleanliness_level', $profile->cleanliness_level) }}">
+        </div>
+        <div class="mb-3">
+            <label class="form-label">Horario de sueño</label>
+            <select name="sleep_schedule" class="form-select">
+                <option value="">Selecciona una opción</option>
+                <option value="madrugador" {{ old('sleep_schedule', $profile->sleep_schedule) == 'madrugador' ? 'selected' : '' }}>Madrugador</option>
+                <option value="noctambulo" {{ old('sleep_schedule', $profile->sleep_schedule) == 'noctambulo' ? 'selected' : '' }}>Noctámbulo</option>
+                <option value="flexible" {{ old('sleep_schedule', $profile->sleep_schedule) == 'flexible' ? 'selected' : '' }}>Flexible</option>
+            </select>
+        </div>
+        <div class="mb-3">
+            <label class="form-label">Hobbies (separados por comas)</label>
+            <input type="text" name="hobbies" class="form-control" value="{{ old('hobbies', $profile->hobbies_string) }}">
+        </div>
+        <div class="mb-3">
+            <label class="form-label">Año académico</label>
+            <input type="text" name="academic_year" class="form-control" value="{{ old('academic_year', $profile->academic_year) }}">
+        </div>
+        <div class="mb-3">
+            <label class="form-label">Carrera</label>
+            <input type="text" name="major" class="form-control" value="{{ old('major', $profile->major) }}">
+        </div>
+        <div class="mb-3">
+            <label class="form-label">Universidad</label>
+            <input type="text" name="university_name" class="form-control" value="{{ old('university_name', $profile->university_name) }}">
+        </div>
+        <div class="mb-3 form-check">
+            <input type="checkbox" name="looking_for_roommate" id="looking_for_roommate" class="form-check-input" value="1" {{ old('looking_for_roommate', $profile->looking_for_roommate) ? 'checked' : '' }}>
+            <label class="form-check-label" for="looking_for_roommate">Busco compañero de piso</label>
+        </div>
+        <div class="mb-3">
+            <label class="form-label">Imagen de perfil</label>
+            <input type="file" name="profile_image" class="form-control">
+        </div>
+        <button type="submit" class="btn btn-primary">Guardar</button>
+    </form>
+</div>
+@endsection

--- a/resources/views/profile/show.blade.php
+++ b/resources/views/profile/show.blade.php
@@ -1,0 +1,23 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="container">
+    <h1 class="mb-4">Mi Perfil</h1>
+    <a href="{{ route('profile.edit') }}" class="btn btn-primary mb-3">Editar Perfil</a>
+    <div class="card">
+        <div class="card-body">
+            @if($profile->profile_image_url)
+                <img src="{{ $profile->profile_image_url }}" alt="Imagen de perfil" class="img-thumbnail mb-3" style="max-width: 200px;">
+            @endif
+            <p><strong>Biografía:</strong> {{ $profile->bio }}</p>
+            <p><strong>Género:</strong> {{ $profile->gender }}</p>
+            <p><strong>Edad:</strong> {{ $profile->age }}</p>
+            <p><strong>Hobbies:</strong> {{ $profile->hobbies_string }}</p>
+            <p><strong>Año académico:</strong> {{ $profile->academic_year }}</p>
+            <p><strong>Carrera:</strong> {{ $profile->major }}</p>
+            <p><strong>Universidad:</strong> {{ $profile->university_name }}</p>
+            <p><strong>Buscando compañero de piso:</strong> {{ $profile->looking_for_roommate ? 'Sí' : 'No' }}</p>
+        </div>
+    </div>
+</div>
+@endsection


### PR DESCRIPTION
## Summary
- add ProfileController with basic CRUD methods
- add profile editing view with fields for all attributes and image upload
- add simple profile display view

## Testing
- `./vendor/bin/phpunit tests/Feature/RegistrationTest.php` *(fails: missing php extensions)*

------
https://chatgpt.com/codex/tasks/task_e_6840058861788329aafa8593bd0a13da