### PR TITLE
Add event reminder command

### DIFF
--- a/app/Console/Commands/NotifyEventAttendees.php
+++ b/app/Console/Commands/NotifyEventAttendees.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\Event;
+use App\Notifications\EventReminderNotification;
+use Illuminate\Console\Command;
+use Illuminate\Support\Carbon;
+
+class NotifyEventAttendees extends Command
+{
+    protected $signature = 'events:notify-attendees';
+
+    protected $description = 'Notify attendees 24 hours before the event starts';
+
+    public function handle(): int
+    {
+        $targetDate = now()->addDay()->toDateString();
+        $events = Event::with('attendees')
+            ->whereDate('date', $targetDate)
+            ->get();
+
+        foreach ($events as $event) {
+            foreach ($event->attendees as $user) {
+                $user->notify(new EventReminderNotification($event));
+            }
+        }
+
+        $this->info('Event reminder notifications sent.');
+        return Command::SUCCESS;
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -5,12 +5,13 @@ namespace App\Console;
 use Illuminate\Console\Application as Artisan;
 use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Foundation\Console\Kernel as ConsoleKernel;
+use App\Console\Commands\NotifyEventAttendees;
 
 class Kernel extends ConsoleKernel
 {
     protected function schedule(Schedule $schedule): void
     {
-        //
+        $schedule->command('events:notify-attendees')->daily();
     }
 
     protected function commands(): void

--- a/app/Notifications/EventReminderNotification.php
+++ b/app/Notifications/EventReminderNotification.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Notifications;
+
+use App\Models\Event;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+
+class EventReminderNotification extends Notification implements ShouldQueue
+{
+    use Queueable;
+
+    protected Event $event;
+
+    public function __construct(Event $event)
+    {
+        $this->event = $event;
+    }
+
+    public function via(object $notifiable): array
+    {
+        return ['mail'];
+    }
+
+    public function toMail(object $notifiable): MailMessage
+    {
+        return (new MailMessage)
+            ->subject('Recordatorio de evento: ' . $this->event->title)
+            ->line('Te recordamos que el evento "' . $this->event->title . '" se celebrará pronto.')
+            ->action('Ver evento', url('/events/' . $this->event->id))
+            ->line('¡Te esperamos!');
+    }
+}


### PR DESCRIPTION
## Summary
- add notification for event reminders
- create command to send reminders 24h before start
- schedule command daily

## Testing
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684005b497a88329bb7dd1a1c5e745c6