### PR TITLE
Display Google Maps for event location

### DIFF
--- a/resources/views/events/show.blade.php
+++ b/resources/views/events/show.blade.php
@@ -9,6 +9,24 @@
     <p><strong>Precio:</strong> {{ $event->formatted_price }}</p>
     <p><strong>Aforo:</strong> {{ $event->current_attendees }} / {{ $event->max_attendees ?? '∞' }}</p>
 
+    @if($event->place)
+        <h4 class="mt-4">Ubicación</h4>
+        <div class="ratio ratio-16x9">
+            <iframe
+                src="{{ $event->place->google_maps_embed_url }}"
+                style="border:0;"
+                allowfullscreen
+                loading="lazy"
+                referrerpolicy="no-referrer-when-downgrade">
+            </iframe>
+        </div>
+        <p class="mt-2">
+            <strong>{{ $event->place->name }}</strong><br>
+            {{ $event->place->formatted_address }}<br>
+            <a href="{{ $event->place->google_maps_link }}" target="_blank" rel="noopener">Ver en Google Maps</a>
+        </p>
+    @endif
+
     @auth
         @if(!$event->is_user_attending && $event->has_available_spots)
             <form method="POST" action="{{ route('events.register', $event) }}" class="d-inline">


### PR DESCRIPTION
## Summary
- embed Google Maps in event details page

## Testing
- `php artisan test --testsuite=Feature --stop-on-failure --testsuite=Unit` *(fails: php command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684005ecba8c8329aab47b9b74989680