### PR TITLE
Implement AJAX suggestions for search fields

### DIFF
--- a/app/Http/Controllers/EventController.php
+++ b/app/Http/Controllers/EventController.php
@@ -248,6 +248,31 @@ class EventController extends Controller
     }
 
     /**
+     * Get event suggestions for autocomplete (AJAX).
+     */
+    public function suggest(Request $request): JsonResponse
+    {
+        $request->validate([
+            'q' => 'required|string|min:2',
+        ]);
+
+        $events = $this->eventService
+            ->searchEvents(['search' => $request->q])
+            ->take(5);
+
+        return response()->json([
+            'success' => true,
+            'events' => $events->map(function ($event) {
+                return [
+                    'id' => $event->id,
+                    'title' => $event->title,
+                    'url' => route('events.show', $event),
+                ];
+            }),
+        ]);
+    }
+
+    /**
      * Get event statistics (AJAX).
      */
     public function statistics(): JsonResponse

--- a/app/Http/Controllers/ListingController.php
+++ b/app/Http/Controllers/ListingController.php
@@ -240,4 +240,29 @@ class ListingController extends Controller
 
         return back()->with('success', "Visita reservada para {$date} a las {$time}.");
     }
+
+    /**
+     * Get listing suggestions for autocomplete (AJAX).
+     */
+    public function suggest(Request $request): JsonResponse
+    {
+        $request->validate([
+            'q' => 'required|string|min:2',
+        ]);
+
+        $listings = $this->listingService
+            ->searchListings(['search' => $request->q])
+            ->take(5);
+
+        return response()->json([
+            'success' => true,
+            'listings' => $listings->map(function ($listing) {
+                return [
+                    'id' => $listing->id,
+                    'title' => $listing->title,
+                    'url' => route('listings.show', $listing),
+                ];
+            }),
+        ]);
+    }
 }

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -1,1 +1,47 @@
 import 'bootstrap';
+
+function initAutocomplete(inputId, endpoint, listId) {
+    const input = document.getElementById(inputId);
+    const list = document.getElementById(listId);
+    if (!input || !list) return;
+
+    input.addEventListener('input', () => {
+        const query = input.value.trim();
+        if (query.length < 2) {
+            list.innerHTML = '';
+            list.classList.add('d-none');
+            return;
+        }
+
+        fetch(`${endpoint}?q=${encodeURIComponent(query)}`)
+            .then(r => r.json())
+            .then(data => {
+                const results = data.listings || data.events || data.results || [];
+                list.innerHTML = '';
+                results.forEach(item => {
+                    const a = document.createElement('a');
+                    a.href = item.url;
+                    a.textContent = item.title;
+                    a.className = 'list-group-item list-group-item-action';
+                    list.appendChild(a);
+                });
+                list.classList.toggle('d-none', results.length === 0);
+            })
+            .catch(() => {
+                list.innerHTML = '';
+                list.classList.add('d-none');
+            });
+    });
+
+    document.addEventListener('click', (e) => {
+        if (e.target !== input && !list.contains(e.target)) {
+            list.innerHTML = '';
+            list.classList.add('d-none');
+        }
+    });
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+    initAutocomplete('listing-search', '/api/listings/suggest', 'listing-suggestions');
+    initAutocomplete('event-search', '/api/events/suggest', 'event-suggestions');
+});

--- a/resources/views/events/index.blade.php
+++ b/resources/views/events/index.blade.php
@@ -3,6 +3,10 @@
 @section('content')
 <div class="container">
     <h1 class="mb-4">Eventos</h1>
+    <form method="GET" class="mb-4 position-relative">
+        <input type="text" name="search" id="event-search" value="{{ request('search') }}" class="form-control" placeholder="Buscar eventos...">
+        <div id="event-suggestions" class="list-group position-absolute w-100 d-none"></div>
+    </form>
     @auth
         <a href="{{ route('events.create') }}" class="btn btn-primary mb-3">Crear evento</a>
     @endauth

--- a/resources/views/listings/index.blade.php
+++ b/resources/views/listings/index.blade.php
@@ -3,8 +3,8 @@
 @section('content')
 <div class="container">
     <h1 class="mb-4">Alojamientos</h1>
-    <form method="GET" class="row g-3 mb-4">
-        <div class="col-md-4">
+    <form method="GET" class="row g-3 mb-4 position-relative">
+        <div class="col-md-3">
             <label class="form-label">Tipo</label>
             <select name="type" class="form-select" onchange="this.form.submit()">
                 <option value="">Todos</option>
@@ -12,11 +12,16 @@
                 <option value="residencia" {{ request('type')=='residencia' ? 'selected' : '' }}>Residencia</option>
             </select>
         </div>
-        <div class="col-md-4">
+        <div class="col-md-3">
             <label class="form-label">Ciudad</label>
             <input type="text" name="city" value="{{ request('city') }}" class="form-control" placeholder="Ciudad">
         </div>
-        <div class="col-md-4 d-flex align-items-end">
+        <div class="col-md-3 position-relative">
+            <label class="form-label">Buscar</label>
+            <input type="text" name="search" id="listing-search" value="{{ request('search') }}" class="form-control" placeholder="Buscar...">
+            <div id="listing-suggestions" class="list-group position-absolute w-100 d-none"></div>
+        </div>
+        <div class="col-md-3 d-flex align-items-end">
             <button type="submit" class="btn btn-primary w-100">Filtrar</button>
         </div>
     </form>

--- a/routes/web.php
+++ b/routes/web.php
@@ -117,6 +117,10 @@ Route::get('/api/events/statistics', [EventController::class, 'statistics'])
 Route::get('/api/events/recommended', [EventController::class, 'recommended'])
     ->middleware('auth')
     ->name('api.events.recommended');
+Route::get('/api/listings/suggest', [ListingController::class, 'suggest'])
+    ->name('api.listings.suggest');
+Route::get('/api/events/suggest', [EventController::class, 'suggest'])
+    ->name('api.events.suggest');
 
 // Rutas de administración
 Route::middleware(['auth', 'admin'])->prefix('admin')->name('admin.')->group(function () {


### PR DESCRIPTION
## Summary
- add suggestion endpoints for listings and events
- hook up new routes for fetching suggestions
- enhance listing & event index pages with search inputs
- implement JS for autocomplete suggestions

## Testing
- `composer install` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_684005f147a48329b05fa2a9c2866e47