### PR TITLE
Add pagination for events and listings

### DIFF
--- a/app/Http/Controllers/EventController.php
+++ b/app/Http/Controllers/EventController.php
@@ -32,7 +32,7 @@ class EventController extends Controller
         ]);
 
         if (!empty(array_filter($filters))) {
-            $events = $this->eventService->searchEvents($filters);
+            $events = $this->eventService->searchEventsPaginated($filters);
         } else {
             $events = $this->eventService->getPaginatedEvents();
         }

--- a/app/Http/Controllers/ListingController.php
+++ b/app/Http/Controllers/ListingController.php
@@ -32,7 +32,7 @@ class ListingController extends Controller
         ]);
 
         if (!empty(array_filter($filters))) {
-            $listings = $this->listingService->searchListings($filters);
+            $listings = $this->listingService->searchListingsPaginated($filters);
         } else {
             $listings = $this->listingService->getPaginatedListings();
         }

--- a/app/Repositories/EloquentListingRepository.php
+++ b/app/Repositories/EloquentListingRepository.php
@@ -97,6 +97,50 @@ class EloquentListingRepository implements ListingRepositoryInterface
         return $query->orderBy('created_at', 'desc')->get();
     }
 
+    public function searchWithFiltersPaginated(array $filters, int $perPage = 15): LengthAwarePaginator
+    {
+        $query = Listing::with('user')->available();
+
+        $query->when(isset($filters['city']), function ($q) use ($filters) {
+            $q->inCity($filters['city']);
+        });
+
+        $query->when(isset($filters['type']), function ($q) use ($filters) {
+            $q->ofType($filters['type']);
+        });
+
+        $query->when(isset($filters['min_price']), function ($q) use ($filters) {
+            $q->where('price', '>=', $filters['min_price']);
+        });
+
+        $query->when(isset($filters['max_price']), function ($q) use ($filters) {
+            $q->where('price', '<=', $filters['max_price']);
+        });
+
+        $query->when(isset($filters['bedrooms']), function ($q) use ($filters) {
+            $q->minBedrooms($filters['bedrooms']);
+        });
+
+        $query->when(isset($filters['bathrooms']), function ($q) use ($filters) {
+            $q->minBathrooms($filters['bathrooms']);
+        });
+
+        $query->when(isset($filters['available_from']), function ($q) use ($filters) {
+            $q->availableFrom($filters['available_from']);
+        });
+
+        $query->when(isset($filters['search']), function ($q) use ($filters) {
+            $q->search($filters['search']);
+        });
+
+        $query->when(isset($filters['latitude']) && isset($filters['longitude']), function ($q) use ($filters) {
+            $radius = $filters['radius'] ?? 5;
+            $q->withinRadius($filters['latitude'], $filters['longitude'], $radius);
+        });
+
+        return $query->orderBy('created_at', 'desc')->paginate($perPage)->withQueryString();
+    }
+
     public function getNearby(float $latitude, float $longitude, float $radius): Collection
     {
         return Listing::with('user')

--- a/app/Repositories/EventRepositoryInterface.php
+++ b/app/Repositories/EventRepositoryInterface.php
@@ -25,6 +25,8 @@ interface EventRepositoryInterface
     public function getByUser(int $userId): Collection;
     
     public function searchWithFilters(array $filters): Collection;
+
+    public function searchWithFiltersPaginated(array $filters, int $perPage = 15): LengthAwarePaginator;
     
     public function getNearby(float $latitude, float $longitude, float $radius): Collection;
 }

--- a/app/Repositories/ListingRepositoryInterface.php
+++ b/app/Repositories/ListingRepositoryInterface.php
@@ -25,6 +25,8 @@ interface ListingRepositoryInterface
     public function getByUser(int $userId): Collection;
     
     public function searchWithFilters(array $filters): Collection;
+
+    public function searchWithFiltersPaginated(array $filters, int $perPage = 15): LengthAwarePaginator;
     
     public function getNearby(float $latitude, float $longitude, float $radius): Collection;
 }

--- a/app/Services/EventService.php
+++ b/app/Services/EventService.php
@@ -5,6 +5,7 @@ namespace App\Services;
 use App\Models\Event;
 use App\Repositories\EventRepositoryInterface;
 use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Pagination\LengthAwarePaginator;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Facades\DB;
@@ -41,6 +42,11 @@ class EventService
     public function searchEvents(array $filters): Collection
     {
         return $this->eventRepository->searchWithFilters($filters);
+    }
+
+    public function searchEventsPaginated(array $filters, int $perPage = 15): LengthAwarePaginator
+    {
+        return $this->eventRepository->searchWithFiltersPaginated($filters, $perPage);
     }
 
     public function getNearbyEvents(float $latitude, float $longitude, float $radius = 10): Collection

--- a/app/Services/ListingService.php
+++ b/app/Services/ListingService.php
@@ -5,6 +5,7 @@ namespace App\Services;
 use App\Models\Listing;
 use App\Repositories\ListingRepositoryInterface;
 use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Pagination\LengthAwarePaginator;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Facades\DB;
@@ -51,6 +52,21 @@ class ListingService
         }
 
         return $this->listingRepository->searchWithFilters($filters);
+    }
+
+    public function searchListingsPaginated(array $filters, int $perPage = 15): LengthAwarePaginator
+    {
+        if (isset($filters['university'])) {
+            $coords = $this->getUniversityCoordinates($filters['university']);
+            if ($coords) {
+                $filters['latitude'] = $coords['lat'];
+                $filters['longitude'] = $coords['lng'];
+                $filters['radius'] = $filters['radius'] ?? 5;
+            }
+            unset($filters['university']);
+        }
+
+        return $this->listingRepository->searchWithFiltersPaginated($filters, $perPage);
     }
 
     public function getNearbyListings(float $latitude, float $longitude, float $radius = 10): Collection

--- a/resources/views/events/index.blade.php
+++ b/resources/views/events/index.blade.php
@@ -19,6 +19,7 @@
             </div>
         </div>
     @endforeach
+    {{ $events->appends(request()->query())->links() }}
 
     @isset($places)
         <hr>

--- a/resources/views/listings/index.blade.php
+++ b/resources/views/listings/index.blade.php
@@ -40,5 +40,6 @@
             </div>
         @endforeach
     </div>
+    {{ $listings->appends(request()->query())->links() }}
 </div>
 @endsection


### PR DESCRIPTION
## Summary
- support paginated filtering for listings and events
- add pagination links to listings and events index

## Testing
- `npm test` *(fails: Missing script)*
- `./vendor/bin/phpunit --stop-on-failure` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684005f790748329b076f589d7638367