### PR TITLE
Configure Axios CSRF token and add middleware test

### DIFF
--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -1,1 +1,13 @@
 import 'bootstrap';
+import axios from 'axios';
+
+window.axios = axios;
+window.axios.defaults.headers.common['X-Requested-With'] = 'XMLHttpRequest';
+
+const token = document.head.querySelector('meta[name="csrf-token"]');
+
+if (token) {
+    window.axios.defaults.headers.common['X-CSRF-TOKEN'] = token.content;
+} else {
+    console.error('CSRF token not found: ensure a meta tag with name "csrf-token" is present');
+}

--- a/tests/Feature/RouteMiddlewareTest.php
+++ b/tests/Feature/RouteMiddlewareTest.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Support\Facades\Route;
+use Tests\TestCase;
+
+class RouteMiddlewareTest extends TestCase
+{
+    public function test_dashboard_route_has_auth_and_verified_middleware(): void
+    {
+        $route = Route::getRoutes()->getByName('dashboard');
+        $this->assertNotNull($route, 'Route named dashboard not found');
+        $middleware = $route->middleware();
+        $this->assertContains('auth', $middleware);
+        $this->assertContains('verified', $middleware);
+    }
+}


### PR DESCRIPTION
## Summary
- configure Axios in `resources/js/app.js` to automatically send CSRF token
- add a feature test to verify that the dashboard route uses `auth` and `verified` middleware

## Testing
- `php artisan test --testsuite=Feature` *(fails: duplicate column name in migration)*

------
https://chatgpt.com/codex/tasks/task_e_684005f91d8c8329a0a0aba4059c1841