### PR TITLE
Add scheduled cleanup for old messages

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -64,3 +64,6 @@ AWS_BUCKET=
 AWS_USE_PATH_STYLE_ENDPOINT=false
 
 VITE_APP_NAME="${APP_NAME}"
+
+# Number of days to keep chat messages
+MESSAGE_RETENTION_DAYS=30

--- a/app/Console/Commands/DeleteOldMessages.php
+++ b/app/Console/Commands/DeleteOldMessages.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use App\Models\Message;
+use Carbon\Carbon;
+
+class DeleteOldMessages extends Command
+{
+    protected $signature = 'messages:delete-old';
+
+    protected $description = 'Delete messages older than configured period';
+
+    public function handle(): int
+    {
+        $days = config('messages.retention_days', 30);
+        $cutoffDate = Carbon::now()->subDays($days);
+
+        $deleted = Message::where('created_at', '<', $cutoffDate)->delete();
+
+        $this->info("Deleted {$deleted} messages older than {$days} days.");
+
+        return Command::SUCCESS;
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -10,7 +10,7 @@ class Kernel extends ConsoleKernel
 {
     protected function schedule(Schedule $schedule): void
     {
-        //
+        $schedule->command('messages:delete-old')->daily();
     }
 
     protected function commands(): void

--- a/config/messages.php
+++ b/config/messages.php
@@ -1,0 +1,5 @@
+<?php
+
+return [
+    'retention_days' => env('MESSAGE_RETENTION_DAYS', 30),
+];


### PR DESCRIPTION
## Summary
- add DeleteOldMessages command
- configure retention days setting
- schedule cleanup command daily

## Testing
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684005fd4ab08329824fc3da6efa18a4