### PR TITLE
Handle missing profiles in controller

### DIFF
--- a/app/Http/Controllers/ProfileController.php
+++ b/app/Http/Controllers/ProfileController.php
@@ -2,7 +2,8 @@
 
 namespace App\Http\Controllers;
 
-
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Storage;
 
 class ProfileController extends Controller
 {
@@ -11,4 +12,69 @@ class ProfileController extends Controller
         $this->middleware(['auth', 'verified']);
     }
 
+    public function show()
+    {
+        $profile = auth()->user()->profile()->firstOrCreate([]);
+        return view('profile.show', compact('profile'));
+    }
 
+    public function edit()
+    {
+        $profile = auth()->user()->profile()->firstOrCreate([]);
+        return view('profile.edit', compact('profile'));
+    }
+
+    public function update(Request $request)
+    {
+        $profile = auth()->user()->profile;
+        if (!$profile) {
+            $profile = auth()->user()->profile()->create([]);
+        }
+
+        $data = $request->validate([
+            'bio' => ['nullable', 'string'],
+            'gender' => ['nullable', 'string'],
+            'age' => ['nullable', 'integer'],
+            'smoking_preference' => ['nullable', 'string'],
+            'pet_preference' => ['nullable', 'string'],
+            'cleanliness_level' => ['nullable', 'integer', 'min:1', 'max:5'],
+            'sleep_schedule' => ['nullable', 'string'],
+            'hobbies' => ['nullable', 'string'],
+            'academic_year' => ['nullable', 'string'],
+            'major' => ['nullable', 'string'],
+            'university_name' => ['nullable', 'string'],
+            'looking_for_roommate' => ['nullable', 'boolean'],
+            'profile_image' => ['nullable', 'image'],
+        ]);
+
+        $data['looking_for_roommate'] = $request->has('looking_for_roommate');
+
+        if (isset($data['hobbies'])) {
+            $data['hobbies'] = array_map('trim', explode(',', $data['hobbies']));
+        }
+
+        if ($request->hasFile('profile_image')) {
+            $path = $request->file('profile_image')->store('profiles', 'public');
+            $data['profile_image'] = $path;
+        } else {
+            unset($data['profile_image']);
+        }
+
+        $profile->update($data);
+
+        return redirect()->route('profile.show')->with('success', 'Perfil actualizado.');
+    }
+
+    public function destroy()
+    {
+        $profile = auth()->user()->profile;
+        if ($profile) {
+            if ($profile->profile_image) {
+                Storage::disk('public')->delete($profile->profile_image);
+            }
+            $profile->delete();
+        }
+
+        return redirect()->route('home')->with('success', 'Perfil eliminado.');
+    }
+}


### PR DESCRIPTION
## Summary
- add full ProfileController implementation
- create the user's profile in `show` and `edit` if missing
- handle null profiles safely when updating or deleting

## Testing
- `phpunit` *(fails: command not found)*
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68400ee20c28832983c5f00f70d2ae8c