### PR TITLE
Fix profile image removal on update and delete

### DIFF
--- a/app/Http/Controllers/ProfileController.php
+++ b/app/Http/Controllers/ProfileController.php
@@ -2,7 +2,11 @@
 
 namespace App\Http\Controllers;
 
-
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Storage;
+use App\Models\Profile;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\View\View;
 
 class ProfileController extends Controller
 {
@@ -11,4 +15,68 @@ class ProfileController extends Controller
         $this->middleware(['auth', 'verified']);
     }
 
+    public function show(): View
+    {
+        $profile = auth()->user()->profile;
+        return view('profile.show', compact('profile'));
+    }
 
+    public function edit(): View
+    {
+        $profile = auth()->user()->profile;
+        return view('profile.edit', compact('profile'));
+    }
+
+    public function update(Request $request): RedirectResponse
+    {
+        $profile = auth()->user()->profile;
+
+        $data = $request->validate([
+            'bio' => ['nullable', 'string'],
+            'gender' => ['nullable', 'string'],
+            'age' => ['nullable', 'integer'],
+            'smoking_preference' => ['nullable', 'string'],
+            'pet_preference' => ['nullable', 'string'],
+            'cleanliness_level' => ['nullable', 'integer', 'min:1', 'max:5'],
+            'sleep_schedule' => ['nullable', 'string'],
+            'hobbies' => ['nullable', 'string'],
+            'academic_year' => ['nullable', 'string'],
+            'major' => ['nullable', 'string'],
+            'university_name' => ['nullable', 'string'],
+            'looking_for_roommate' => ['nullable', 'boolean'],
+            'profile_image' => ['nullable', 'image'],
+        ]);
+
+        $data['looking_for_roommate'] = $request->has('looking_for_roommate');
+
+        if (isset($data['hobbies'])) {
+            $data['hobbies'] = array_map('trim', explode(',', $data['hobbies']));
+        }
+
+        if ($request->hasFile('profile_image')) {
+            if ($profile && $profile->profile_image) {
+                Storage::disk('public')->delete($profile->profile_image);
+            }
+            $path = $request->file('profile_image')->store('profiles', 'public');
+            $data['profile_image'] = $path;
+        } else {
+            unset($data['profile_image']);
+        }
+
+        $profile->update($data);
+
+        return redirect()->route('profile.show')->with('success', 'Perfil actualizado.');
+    }
+
+    public function destroy(): RedirectResponse
+    {
+        $profile = auth()->user()->profile;
+        if ($profile) {
+            if ($profile->profile_image) {
+                Storage::disk('public')->delete($profile->profile_image);
+            }
+            $profile->delete();
+        }
+        return redirect()->route('home')->with('success', 'Perfil eliminado.');
+    }
+}


### PR DESCRIPTION
## Summary
- restore ProfileController functionality and remove old profile images when updating
- ensure profile image is deleted before removing profile

## Testing
- `composer install`
- `./vendor/bin/phpunit --testdox` *(fails: ParseError in migration)*

------
https://chatgpt.com/codex/tasks/task_e_68400ee2eb688329bd529296850c4f34