### PR TITLE
Implement UserMatch creation/update logic

### DIFF
--- a/app/Models/RoomMatch.php
+++ b/app/Models/RoomMatch.php
@@ -9,6 +9,8 @@ class RoomMatch extends Model
 {
     use HasFactory;
 
+    protected $table = 'matches';
+
     protected $fillable = [
         'user_id_1',
         'user_id_2',

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -12,7 +12,7 @@ use App\Models\Subscription;
 
 class User extends Authenticatable implements MustVerifyEmail
 {
-
+    use HasFactory, Notifiable;
 
     /**
      * The attributes that are mass assignable.

--- a/app/Models/UserMatch.php
+++ b/app/Models/UserMatch.php
@@ -9,6 +9,8 @@ class UserMatch extends Model
 {
     use HasFactory;
 
+    protected $table = 'matches';
+
 
     protected $fillable = [
         'user_id_1',
@@ -46,7 +48,7 @@ class UserMatch extends Model
      */
     public function messages()
     {
-
+        return $this->hasMany(Message::class);
     }
 
     /**
@@ -107,7 +109,24 @@ class UserMatch extends Model
     /**
      * Create or update a match between two users.
      */
+    public static function createOrUpdateMatch($user1Id, $user2Id, $status)
+    {
+        // Keep track of the acting user
+        $actingUserId = $user1Id;
 
+        // Ensure consistent ordering (smaller ID first)
+        if ($user1Id > $user2Id) {
+            [$user1Id, $user2Id] = [$user2Id, $user1Id];
+        }
+
+        // Find existing match or create a new one
+        $match = self::firstOrCreate([
+            'user_id_1' => $user1Id,
+            'user_id_2' => $user2Id,
+        ]);
+
+        // Update the status for the acting user
+        $match->updateStatusForUser($actingUserId, $status);
 
         return $match;
     }

--- a/database/migrations/2024_01_08_add_is_admin_to_users_table.php
+++ b/database/migrations/2024_01_08_add_is_admin_to_users_table.php
@@ -22,7 +22,11 @@ return new class extends Migration
     public function down(): void
     {
         Schema::table('users', function (Blueprint $table) {
-
+            if (Schema::hasColumn('users', 'is_admin')) {
+                $table->dropColumn('is_admin');
+            }
+            if (Schema::hasColumn('users', 'email_verified_at')) {
+                $table->dropColumn('email_verified_at');
             }
         });
     }

--- a/database/migrations/2025_06_05_010000_add_category_id_to_events_table.php
+++ b/database/migrations/2025_06_05_010000_add_category_id_to_events_table.php
@@ -10,7 +10,10 @@ return new class extends Migration
     {
         Schema::table('events', function (Blueprint $table) {
             $table->foreignId('category_id')->nullable()->after('user_id')->constrained()->onDelete('set null');
-            $table->dropColumn('category');
+            if (Schema::hasColumn('events', 'category')) {
+                $table->dropIndex(['category', 'is_public']);
+                $table->dropColumn('category');
+            }
             $table->index('category_id');
         });
     }


### PR DESCRIPTION
## Summary
- implement `messages` relation for `UserMatch`
- implement `createOrUpdateMatch` in `UserMatch`
- fix migrations for SQLite compatibility
- adjust `RoomMatch` and `UserMatch` table names
- update `RoomieMatchService` minimal logic
- enable factories on `User`

## Testing
- `vendor/bin/phpunit --filter=RoomieMatchServiceTest`

------
https://chatgpt.com/codex/tasks/task_e_684020e165b883298f82683c4d0c0a83