### PR TITLE
Store match votes with createOrUpdateMatch

### DIFF
--- a/app/Services/RoomieMatchService.php
+++ b/app/Services/RoomieMatchService.php
@@ -77,16 +77,20 @@ class RoomieMatchService
         });
     }
 
-    public function dislikeUser(int $fromUserId, int $toUserId): bool
+    public function dislikeUser(int $fromUserId, int $toUserId): array
     {
         return DB::transaction(function () use ($fromUserId, $toUserId) {
             if ($fromUserId == $toUserId) {
                 throw new \Exception('No puedes rechazarte a ti mismo.');
             }
 
-            UserMatch::createOrUpdateMatch($fromUserId, $toUserId, 'disliked');
+            $match = UserMatch::createOrUpdateMatch($fromUserId, $toUserId, 'disliked');
 
-            return true;
+            return [
+                'success' => true,
+                'match_id' => $match->id,
+                'message' => 'Dislike enviado correctamente.',
+            ];
         });
     }
 

--- a/tests/Unit/RoomieMatchServiceTest.php
+++ b/tests/Unit/RoomieMatchServiceTest.php
@@ -4,7 +4,7 @@ namespace Tests\Unit;
 
 use App\Models\Profile;
 use App\Models\User;
-use App\Models\UserMatch;
+use App\Models\RoomMatch;
 use App\Services\RoomieMatchService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
@@ -47,10 +47,14 @@ class RoomieMatchServiceTest extends TestCase
         $user1 = $this->createUserWithProfile();
         $user2 = $this->createUserWithProfile();
 
-        $this->service->dislikeUser($user1->id, $user2->id);
+        $result = $this->service->dislikeUser($user1->id, $user2->id);
 
-        $match = UserMatch::first();
-        $this->assertNotNull($match);
+        $this->assertTrue($result['success']);
+        $this->assertDatabaseHas('matches', [
+            'id' => $result['match_id'],
+        ]);
+
+        $match = RoomMatch::find($result['match_id']);
         $this->assertTrue(
             ($match->user_id_1 === $user1->id && $match->user_1_status === 'disliked') ||
             ($match->user_id_2 === $user1->id && $match->user_2_status === 'disliked')
@@ -66,7 +70,7 @@ class RoomieMatchServiceTest extends TestCase
         $result = $this->service->likeUser($user2->id, $user1->id);
 
         $this->assertTrue($result['is_mutual_match']);
-        $match = UserMatch::find($result['match_id']);
+        $match = RoomMatch::find($result['match_id']);
         $this->assertNotNull($match->matched_at);
     }
 }


### PR DESCRIPTION
## Summary
- use `createOrUpdateMatch` helper when liking/disliking a user
- return more info from `dislikeUser`
- adapt `RoomieMatchServiceTest` expectations

## Testing
- `./vendor/bin/phpunit --testsuite Unit`

------
https://chatgpt.com/codex/tasks/task_e_68402712ed9c8329943b6a28c12ad248