### PR TITLE
Add geocoding with Google Maps

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -70,3 +70,6 @@ AWS_BUCKET=
 AWS_USE_PATH_STYLE_ENDPOINT=false
 
 VITE_APP_NAME="${APP_NAME}"
+
+# Google Maps API key for geocoding addresses
+GOOGLE_MAPS_API_KEY=

--- a/tests/Unit/ListingServiceGeocodeTest.php
+++ b/tests/Unit/ListingServiceGeocodeTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Services\ListingService;
+use Illuminate\Support\Facades\Http;
+use Tests\TestCase;
+
+class ListingServiceGeocodeTest extends TestCase
+{
+    /**
+     * Creates a minimal subclass exposing the geocodeAddress method.
+     */
+    private function service(): ListingService
+    {
+        return new class extends ListingService {
+            public function __construct()
+            {
+                // Skip parent constructor
+            }
+
+            public function geocode(string $address)
+            {
+                return $this->geocodeAddress($address);
+            }
+        };
+    }
+
+    public function test_geocode_address_returns_coordinates(): void
+    {
+        Http::fake([
+            'https://maps.googleapis.com/maps/api/geocode/json*' => Http::response([
+                'results' => [
+                    [
+                        'geometry' => [
+                            'location' => ['lat' => 1.23, 'lng' => 4.56],
+                        ],
+                    ],
+                ],
+                'status' => 'OK',
+            ], 200),
+        ]);
+
+        $result = $this->service()->geocode('Test Address');
+
+        $this->assertSame(['lat' => 1.23, 'lng' => 4.56], $result);
+    }
+
+    public function test_geocode_address_returns_null_on_failure(): void
+    {
+        Http::fake([
+            'https://maps.googleapis.com/maps/api/geocode/json*' => Http::response([], 500),
+        ]);
+
+        $result = $this->service()->geocode('Bad Address');
+
+        $this->assertNull($result);
+    }
+}
+


### PR DESCRIPTION
## Summary
- implement geocodeAddress using Google Maps API
- configure API key in `.env`
- add unit tests for geocoding

## Testing
- `php artisan test` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68402936098083298f352ce02a0e04af