### PR TITLE
Fix match alias in channels route

### DIFF
--- a/routes/channels.php
+++ b/routes/channels.php
@@ -1,7 +1,7 @@
 <?php
 
 use Illuminate\Support\Facades\Broadcast;
-use App\Models\Match as RoomMatch;
+use App\Models\RoomMatch;
 
 Broadcast::channel('match.{matchId}', function ($user, int $matchId) {
     return RoomMatch::where('id', $matchId)


### PR DESCRIPTION
## Summary
- correct model alias for private channel broadcast

## Testing
- `php artisan test` *(fails: Failed opening required 'vendor/autoload.php')*

------
https://chatgpt.com/codex/tasks/task_e_68402a4263f0832996656571f88f3fef