### PR TITLE
Add custom 404 error view

### DIFF
--- a/resources/views/errors/404.blade.php
+++ b/resources/views/errors/404.blade.php
@@ -1,0 +1,9 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="container py-5 text-center">
+    <h1 class="display-4">Página no encontrada</h1>
+    <p class="lead">La página que buscas no existe.</p>
+    <a href="{{ url('/') }}" class="btn btn-primary mt-3">Volver al inicio</a>
+</div>
+@endsection


### PR DESCRIPTION
## Summary
- show a friendly 404 error page
- include a link to return home

## Testing
- `npm run test:e2e` *(fails: playwright not found)*

------
https://chatgpt.com/codex/tasks/task_e_68402bc165248329a5a9a98463f70864