### PR TITLE
Add RESTful API controllers

### DIFF
--- a/app/Http/Controllers/API/EventController.php
+++ b/app/Http/Controllers/API/EventController.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace App\Http\Controllers\API;
+
+use App\Http\Controllers\Controller;
+use App\Services\EventService;
+use App\Http\Requests\StoreEventRequest;
+use App\Http\Requests\UpdateEventRequest;
+use App\Http\Resources\EventResource;
+use Illuminate\Http\Request;
+use Illuminate\Http\JsonResponse;
+
+class EventController extends Controller
+{
+    protected EventService $eventService;
+
+    public function __construct(EventService $eventService)
+    {
+        $this->eventService = $eventService;
+    }
+
+    public function index(Request $request): JsonResponse
+    {
+        $filters = $request->only([
+            'category', 'date', 'start_date', 'end_date',
+            'city', 'free', 'available_spots', 'search'
+        ]);
+
+        if (!empty(array_filter($filters))) {
+            $events = $this->eventService->searchEventsPaginated($filters);
+        } else {
+            $events = $this->eventService->getPaginatedEvents();
+        }
+
+        return response()->json(EventResource::collection($events));
+    }
+
+    public function store(StoreEventRequest $request): JsonResponse
+    {
+        $image = $request->file('image');
+        $event = $this->eventService->createEvent($request->validated(), $image);
+
+        return response()->json(new EventResource($event), 201);
+    }
+
+    public function show(int $id): JsonResponse
+    {
+        $event = $this->eventService->findEvent($id);
+
+        if (!$event) {
+            return response()->json(['message' => 'Event not found'], 404);
+        }
+
+        return response()->json(new EventResource($event));
+    }
+
+    public function update(UpdateEventRequest $request, int $id): JsonResponse
+    {
+        $image = $request->file('image');
+        $updated = $this->eventService->updateEvent($id, $request->validated(), $image);
+
+        if (!$updated) {
+            return response()->json(['message' => 'Event not found'], 404);
+        }
+
+        $event = $this->eventService->findEvent($id);
+
+        return response()->json(new EventResource($event));
+    }
+
+    public function destroy(int $id): JsonResponse
+    {
+        $deleted = $this->eventService->deleteEvent($id);
+
+        if (!$deleted) {
+            return response()->json(['message' => 'Event not found'], 404);
+        }
+
+        return response()->json(status: 204);
+    }
+}

--- a/app/Http/Controllers/API/ListingController.php
+++ b/app/Http/Controllers/API/ListingController.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace App\Http\Controllers\API;
+
+use App\Http\Controllers\Controller;
+use App\Services\ListingService;
+use App\Http\Requests\StoreListingRequest;
+use App\Http\Requests\UpdateListingRequest;
+use App\Http\Resources\ListingResource;
+use Illuminate\Http\Request;
+use Illuminate\Http\JsonResponse;
+
+class ListingController extends Controller
+{
+    protected ListingService $listingService;
+
+    public function __construct(ListingService $listingService)
+    {
+        $this->listingService = $listingService;
+    }
+
+    public function index(Request $request): JsonResponse
+    {
+        $filters = $request->only([
+            'city', 'type', 'min_price', 'max_price',
+            'bedrooms', 'bathrooms', 'available_from', 'search'
+        ]);
+
+        if (!empty(array_filter($filters))) {
+            $listings = $this->listingService->searchListingsPaginated($filters);
+        } else {
+            $listings = $this->listingService->getPaginatedListings();
+        }
+
+        return response()->json(ListingResource::collection($listings));
+    }
+
+    public function store(StoreListingRequest $request): JsonResponse
+    {
+        $images = $request->file('images', []);
+        $listing = $this->listingService->createListing($request->validated(), $images);
+
+        return response()->json(new ListingResource($listing), 201);
+    }
+
+    public function show(int $id): JsonResponse
+    {
+        $listing = $this->listingService->findListing($id);
+
+        if (!$listing) {
+            return response()->json(['message' => 'Listing not found'], 404);
+        }
+
+        return response()->json(new ListingResource($listing));
+    }
+
+    public function update(UpdateListingRequest $request, int $id): JsonResponse
+    {
+        $images = $request->file('images', []);
+        $updated = $this->listingService->updateListing($id, $request->validated(), $images);
+
+        if (!$updated) {
+            return response()->json(['message' => 'Listing not found'], 404);
+        }
+
+        $listing = $this->listingService->findListing($id);
+
+        return response()->json(new ListingResource($listing));
+    }
+
+    public function destroy(int $id): JsonResponse
+    {
+        $deleted = $this->listingService->deleteListing($id);
+
+        if (!$deleted) {
+            return response()->json(['message' => 'Listing not found'], 404);
+        }
+
+        return response()->json(status: 204);
+    }
+}

--- a/app/Http/Resources/EventResource.php
+++ b/app/Http/Resources/EventResource.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class EventResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray($request): array
+    {
+        return [
+            'id' => $this->id,
+            'user_id' => $this->user_id,
+            'title' => $this->title,
+            'description' => $this->description,
+            'date' => $this->date,
+            'time' => $this->time?->format('H:i'),
+            'end_datetime' => $this->end_datetime,
+            'place_id' => $this->place_id,
+            'category_id' => $this->category_id,
+            'is_public' => $this->is_public,
+            'price' => $this->price,
+            'max_attendees' => $this->max_attendees,
+            'current_attendees' => $this->current_attendees,
+            'image_url' => $this->image_url,
+            'location' => $this->location,
+            'created_at' => $this->created_at,
+            'updated_at' => $this->updated_at,
+        ];
+    }
+}

--- a/app/Http/Resources/ListingResource.php
+++ b/app/Http/Resources/ListingResource.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class ListingResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray($request): array
+    {
+        return [
+            'id' => $this->id,
+            'user_id' => $this->user_id,
+            'title' => $this->title,
+            'description' => $this->description,
+            'address' => $this->address,
+            'city' => $this->city,
+            'zip_code' => $this->zip_code,
+            'price' => $this->price,
+            'type' => $this->type,
+            'square_meters' => $this->square_meters,
+            'current_occupants' => $this->current_occupants,
+            'max_occupants' => $this->max_occupants,
+            'phone' => $this->phone,
+            'bedrooms' => $this->bedrooms,
+            'bathrooms' => $this->bathrooms,
+            'available_from' => $this->available_from,
+            'is_available' => $this->is_available,
+            'image_urls' => $this->image_urls,
+            'latitude' => $this->latitude,
+            'longitude' => $this->longitude,
+            'created_at' => $this->created_at,
+            'updated_at' => $this->updated_at,
+        ];
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,3 +1,18 @@
 <?php
 
+use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\API\AuthController;
+use App\Http\Controllers\API\ListingController as ApiListingController;
+use App\Http\Controllers\API\EventController as ApiEventController;
 
+Route::post('/login', [AuthController::class, 'login']);
+
+Route::middleware('auth:sanctum')->group(function () {
+    Route::post('/logout', [AuthController::class, 'logout']);
+
+    Route::apiResource('listings', ApiListingController::class)->except(['index', 'show']);
+    Route::apiResource('events', ApiEventController::class)->except(['index', 'show']);
+});
+
+Route::apiResource('listings', ApiListingController::class)->only(['index', 'show']);
+Route::apiResource('events', ApiEventController::class)->only(['index', 'show']);


### PR DESCRIPTION
## Summary
- set up API endpoints in `routes/api.php`
- add API controllers for listings and events
- add resources to shape listing/event JSON responses

## Testing
- `php -l routes/api.php`
- `php -l app/Http/Controllers/API/ListingController.php`
- `php -l app/Http/Controllers/API/EventController.php`
- `php -l app/Http/Resources/ListingResource.php`
- `php -l app/Http/Resources/EventResource.php`
- `./vendor/bin/phpunit --testsuite Feature` *(fails: could not find driver)*

------
https://chatgpt.com/codex/tasks/task_e_68405294d4f88329af3dc928a7af92dc