### PR TITLE
Improve layout and pages styling

### DIFF
--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -1,3 +1,4 @@
+import 'bootstrap';
 import axios from 'axios';
 
 document.addEventListener('DOMContentLoaded', () => {
@@ -8,6 +9,19 @@ document.addEventListener('DOMContentLoaded', () => {
         'X-Requested-With': 'XMLHttpRequest',
         'Accept': 'application/json'
     };
+
+    const htmlEl = document.documentElement;
+    const storedTheme = localStorage.getItem('theme');
+    if (storedTheme) htmlEl.setAttribute('data-bs-theme', storedTheme);
+
+    const themeToggle = document.getElementById('theme-toggle');
+    if (themeToggle) {
+        themeToggle.addEventListener('click', () => {
+            const newTheme = htmlEl.getAttribute('data-bs-theme') === 'dark' ? 'light' : 'dark';
+            htmlEl.setAttribute('data-bs-theme', newTheme);
+            localStorage.setItem('theme', newTheme);
+        });
+    }
 
     function showMatchNotification(name) {
         const alert = document.getElementById('matchNotification');

--- a/resources/sass/app.scss
+++ b/resources/sass/app.scss
@@ -1,6 +1,4 @@
-
 @import url('https://fonts.bunny.net/css?family=Nunito');
 
-@tailwind base;
-@tailwind components;
-@tailwind utilities;
+@import 'variables';
+@import 'bootstrap/scss/bootstrap';

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -1,36 +1,34 @@
 @extends('layouts.app')
 
 @section('content')
-<div class="max-w-md mx-auto mt-8">
-    <div class="bg-white shadow rounded-lg">
-        <div class="bg-blue-600 text-white px-6 py-3">{{ __('Login') }}</div>
-        <div class="p-6">
-            <form method="POST" action="{{ route('login') }}" class="space-y-4">
+<div class="container py-5" style="max-width: 500px;">
+    <div class="card shadow">
+        <div class="card-header bg-primary text-white">{{ __('Login') }}</div>
+        <div class="card-body">
+            <form method="POST" action="{{ route('login') }}">
                 @csrf
-                <div>
-                    <label for="email" class="block text-sm font-medium">{{ __('Email Address') }}</label>
-                    <input id="email" type="email" name="email" value="{{ old('email') }}" required autofocus class="mt-1 w-full rounded-md border-gray-300" autocomplete="email">
+                <div class="mb-3">
+                    <label for="email" class="form-label">{{ __('Email Address') }}</label>
+                    <input id="email" type="email" name="email" value="{{ old('email') }}" required autofocus class="form-control" autocomplete="email">
                     @error('email')
-                        <p class="text-red-500 text-sm mt-1">{{ $message }}</p>
+                        <div class="text-danger small">{{ $message }}</div>
                     @enderror
                 </div>
-                <div>
-                    <label for="password" class="block text-sm font-medium">{{ __('Password') }}</label>
-                    <input id="password" type="password" name="password" required class="mt-1 w-full rounded-md border-gray-300" autocomplete="current-password">
+                <div class="mb-3">
+                    <label for="password" class="form-label">{{ __('Password') }}</label>
+                    <input id="password" type="password" name="password" required class="form-control" autocomplete="current-password">
                     @error('password')
-                        <p class="text-red-500 text-sm mt-1">{{ $message }}</p>
+                        <div class="text-danger small">{{ $message }}</div>
                     @enderror
                 </div>
-                <div class="flex items-center">
-                    <input class="h-4 w-4 mr-2" type="checkbox" name="remember" id="remember" {{ old('remember') ? 'checked' : '' }}>
-                    <label for="remember" class="text-sm">{{ __('Remember Me') }}</label>
+                <div class="form-check mb-3">
+                    <input class="form-check-input" type="checkbox" name="remember" id="remember" {{ old('remember') ? 'checked' : '' }}>
+                    <label class="form-check-label" for="remember">{{ __('Remember Me') }}</label>
                 </div>
-                <div>
-                    <button type="submit" class="w-full bg-blue-600 text-white py-2 rounded">{{ __('Login') }}</button>
+                <div class="d-grid gap-2">
+                    <button type="submit" class="btn btn-primary">{{ __('Login') }}</button>
                     @if (Route::has('password.request'))
-                        <a class="text-sm text-blue-600 hover:underline block mt-2" href="{{ route('password.request') }}">
-                            {{ __('Forgot Your Password?') }}
-                        </a>
+                        <a class="small text-center" href="{{ route('password.request') }}">{{ __('Forgot Your Password?') }}</a>
                     @endif
                 </div>
             </form>

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -1,49 +1,49 @@
 @extends('layouts.app')
 
 @section('content')
-<div class="max-w-md mx-auto mt-8">
-    <div class="bg-white shadow rounded-lg">
-        <div class="bg-blue-600 text-white px-6 py-3">{{ __('Register') }}</div>
-        <div class="p-6">
-            <form method="POST" action="{{ route('register') }}" class="space-y-4">
+<div class="container py-5" style="max-width: 600px;">
+    <div class="card shadow">
+        <div class="card-header bg-primary text-white">{{ __('Register') }}</div>
+        <div class="card-body">
+            <form method="POST" action="{{ route('register') }}">
                 @csrf
-                <div>
-                    <label for="name" class="block text-sm font-medium">{{ __('Name') }}</label>
-                    <input id="name" type="text" name="name" value="{{ old('name') }}" required autofocus class="mt-1 w-full rounded-md border-gray-300" autocomplete="name">
+                <div class="mb-3">
+                    <label for="name" class="form-label">{{ __('Name') }}</label>
+                    <input id="name" type="text" name="name" value="{{ old('name') }}" required autofocus class="form-control" autocomplete="name">
                     @error('name')
-                        <p class="text-red-500 text-sm mt-1">{{ $message }}</p>
+                        <div class="text-danger small">{{ $message }}</div>
                     @enderror
                 </div>
-                <div>
-                    <label for="email" class="block text-sm font-medium">{{ __('Email Address') }}</label>
-                    <input id="email" type="email" name="email" value="{{ old('email') }}" required class="mt-1 w-full rounded-md border-gray-300" autocomplete="email">
+                <div class="mb-3">
+                    <label for="email" class="form-label">{{ __('Email Address') }}</label>
+                    <input id="email" type="email" name="email" value="{{ old('email') }}" required class="form-control" autocomplete="email">
                     @error('email')
-                        <p class="text-red-500 text-sm mt-1">{{ $message }}</p>
+                        <div class="text-danger small">{{ $message }}</div>
                     @enderror
                 </div>
-                <div>
-                    <label for="role" class="block text-sm font-medium">{{ __('Register As') }}</label>
-                    <select id="role" name="role" required class="mt-1 w-full rounded-md border-gray-300">
+                <div class="mb-3">
+                    <label for="role" class="form-label">{{ __('Register As') }}</label>
+                    <select id="role" name="role" required class="form-select">
                         <option value="student" {{ old('role') == 'student' ? 'selected' : '' }}>Estudiante</option>
                         <option value="owner" {{ old('role') == 'owner' ? 'selected' : '' }}>Propietario</option>
                     </select>
                     @error('role')
-                        <p class="text-red-500 text-sm mt-1">{{ $message }}</p>
+                        <div class="text-danger small">{{ $message }}</div>
                     @enderror
                 </div>
-                <div>
-                    <label for="password" class="block text-sm font-medium">{{ __('Password') }}</label>
-                    <input id="password" type="password" name="password" required class="mt-1 w-full rounded-md border-gray-300" autocomplete="new-password">
+                <div class="mb-3">
+                    <label for="password" class="form-label">{{ __('Password') }}</label>
+                    <input id="password" type="password" name="password" required class="form-control" autocomplete="new-password">
                     @error('password')
-                        <p class="text-red-500 text-sm mt-1">{{ $message }}</p>
+                        <div class="text-danger small">{{ $message }}</div>
                     @enderror
                 </div>
-                <div>
-                    <label for="password-confirm" class="block text-sm font-medium">{{ __('Confirm Password') }}</label>
-                    <input id="password-confirm" type="password" name="password_confirmation" required class="mt-1 w-full rounded-md border-gray-300" autocomplete="new-password">
+                <div class="mb-3">
+                    <label for="password-confirm" class="form-label">{{ __('Confirm Password') }}</label>
+                    <input id="password-confirm" type="password" name="password_confirmation" required class="form-control" autocomplete="new-password">
                 </div>
-                <div>
-                    <button type="submit" class="w-full bg-blue-600 text-white py-2 rounded">{{ __('Register') }}</button>
+                <div class="d-grid">
+                    <button type="submit" class="btn btn-primary">{{ __('Register') }}</button>
                 </div>
             </form>
         </div>

--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -1,15 +1,10 @@
 @extends('layouts.app')
 
 @section('content')
-<div class="bg-gray-100 py-10">
-    <div class="max-w-7xl mx-auto px-4">
-        <h1 class="text-2xl font-semibold mb-4">{{ __('Dashboard') }}</h1>
-        @if (session('status'))
-            <div class="mb-4 p-4 bg-green-100 text-green-800 rounded">
-                {{ session('status') }}
-            </div>
-        @endif
-
-    </div>
+<div class="container py-5">
+    <h1 class="mb-4">{{ __('Dashboard') }}</h1>
+    @if (session('status'))
+        <div class="alert alert-success">{{ session('status') }}</div>
+    @endif
 </div>
 @endsection

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="{{ str_replace('_', '-', app()->getLocale()) }}" class="h-100">
+<html lang="{{ str_replace('_', '-', app()->getLocale()) }}" data-bs-theme="light" class="h-100">
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -13,15 +13,72 @@
     <link rel="dns-prefetch" href="//fonts.bunny.net">
     <link href="https://fonts.bunny.net/css?family=Nunito" rel="stylesheet">
 
+    <!-- Icons -->
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.1/font/bootstrap-icons.min.css" rel="stylesheet">
+
     @vite(['resources/sass/app.scss', 'resources/js/app.js'])
 </head>
+<body class="d-flex flex-column min-vh-100">
+    <div id="app" class="flex-grow-1 d-flex flex-column">
+        <nav class="navbar navbar-expand-md bg-body-tertiary shadow-sm mb-4">
+            <div class="container">
+                <a class="navbar-brand" href="{{ url('/') }}">
+                    {{ config('app.name', 'Laravel') }}
+                </a>
+                <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="{{ __('Toggle navigation') }}">
+                    <span class="navbar-toggler-icon"></span>
+                </button>
 
+                <div class="collapse navbar-collapse" id="navbarSupportedContent">
+                    <ul class="navbar-nav me-auto mb-2 mb-md-0">
+                        <li class="nav-item"><a class="nav-link" href="{{ route('listings.index') }}">Alojamientos</a></li>
+                        <li class="nav-item"><a class="nav-link" href="{{ route('events.index') }}">Eventos</a></li>
+                        <li class="nav-item"><a class="nav-link" href="{{ route('roomie.index') }}">Roomie Match</a></li>
+                    </ul>
 
+                    <ul class="navbar-nav ms-auto align-items-center mb-2 mb-md-0">
+                        <li class="nav-item me-2">
+                            <button id="theme-toggle" type="button" class="btn btn-link nav-link px-2"><i class="bi bi-moon-fill"></i></button>
+                        </li>
+                        @guest
+                            @if (Route::has('login'))
+                                <li class="nav-item">
+                                    <a class="nav-link" href="{{ route('login') }}">{{ __('Login') }}</a>
+                                </li>
+                            @endif
+                            @if (Route::has('register'))
+                                <li class="nav-item">
+                                    <a class="nav-link" href="{{ route('register') }}">{{ __('Register') }}</a>
+                                </li>
+                            @endif
+                        @else
+                            <li class="nav-item dropdown">
+                                <a id="navbarDropdown" class="nav-link dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false" v-pre>
+                                    {{ Auth::user()->name }}
+                                </a>
+
+                                <div class="dropdown-menu dropdown-menu-end" aria-labelledby="navbarDropdown">
+                                    <a class="dropdown-item" href="{{ route('listings.my') }}">Mis anuncios</a>
+                                    <a class="dropdown-item" href="{{ route('events.my') }}">Mis eventos</a>
+                                    <a class="dropdown-item" href="{{ route('profile.show') }}">Perfil</a>
+                                    <hr class="dropdown-divider">
+                                    <a class="dropdown-item" href="{{ route('logout') }}"
+                                       onclick="event.preventDefault(); document.getElementById('logout-form').submit();">
+                                        {{ __('Logout') }}
+                                    </a>
+
+                                    <form id="logout-form" action="{{ route('logout') }}" method="POST" class="d-none">
+                                        @csrf
+                                    </form>
+                                </div>
+                            </li>
+                        @endguest
+                    </ul>
                 </div>
             </div>
         </nav>
 
-        <main class="py-6">
+        <main class="flex-grow-1">
             @yield('content')
         </main>
     </div>

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -1,25 +1,27 @@
 @extends('layouts.app')
 
 @section('content')
-<div class="bg-blue-600 text-white py-12">
-    <div class="max-w-7xl mx-auto px-4 text-center">
-        <h1 class="text-4xl font-bold mb-2">Bienvenido a Spandam</h1>
-        <p class="text-xl">Tu plataforma integral para universitarios</p>
-        <a href="{{ route('register') }}" class="mt-4 inline-block bg-white text-blue-600 px-6 py-3 rounded shadow">Regístrate</a>
+<div class="bg-primary text-white py-5">
+    <div class="container text-center">
+        <h1 class="display-4 mb-2">Bienvenido a Spandam</h1>
+        <p class="lead">Tu plataforma integral para universitarios</p>
+        <a href="{{ route('register') }}" class="btn btn-light mt-3">Regístrate</a>
     </div>
 </div>
-<div class="max-w-7xl mx-auto grid md:grid-cols-3 gap-8 py-12 px-4 text-center">
-    <div>
-        <h3 class="text-lg font-semibold mb-2">Alojamientos</h3>
-        <p>Encuentra y publica pisos de forma sencilla y segura.</p>
-    </div>
-    <div>
-        <h3 class="text-lg font-semibold mb-2">RoomieMatch</h3>
-        <p>Conecta con compañeros de piso compatibles contigo.</p>
-    </div>
-    <div>
-        <h3 class="text-lg font-semibold mb-2">Eventos</h3>
-        <p>Descubre y organiza eventos universitarios cerca de ti.</p>
+<div class="container py-5">
+    <div class="row text-center g-4">
+        <div class="col-md-4">
+            <h3>Alojamientos</h3>
+            <p>Encuentra y publica pisos de forma sencilla y segura.</p>
+        </div>
+        <div class="col-md-4">
+            <h3>RoomieMatch</h3>
+            <p>Conecta con compañeros de piso compatibles contigo.</p>
+        </div>
+        <div class="col-md-4">
+            <h3>Eventos</h3>
+            <p>Descubre y organiza eventos universitarios cerca de ti.</p>
+        </div>
     </div>
 </div>
 @endsection


### PR DESCRIPTION
## Summary
- switch SCSS build back to Bootstrap
- implement dark mode toggler and responsive navigation
- convert landing, dashboard, login and register to Bootstrap

## Testing
- `npm run test:e2e` *(fails: playwright not found)*

------
https://chatgpt.com/codex/tasks/task_e_684056f122108329b7521621667dff12