### PR TITLE
Add feature tests for error pages and broadcast auth

### DIFF
--- a/tests/Feature/BroadcastAuthorizationTest.php
+++ b/tests/Feature/BroadcastAuthorizationTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\RoomMatch;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class BroadcastAuthorizationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_authorizes_when_user_is_match_member(): void
+    {
+        $user1 = User::factory()->create();
+        $user2 = User::factory()->create();
+
+        $match = RoomMatch::create([
+            'user_id_1' => $user1->id,
+            'user_id_2' => $user2->id,
+            'user_1_status' => 'liked',
+            'user_2_status' => 'liked',
+            'matched_at' => now(),
+        ]);
+
+        $response = $this->actingAs($user1)->post('/broadcasting/auth', [
+            'socket_id' => '1234.5678',
+            'channel_name' => "private-match.{$match->id}",
+        ]);
+
+        $response->assertStatus(200);
+    }
+
+    public function test_denies_when_user_is_not_match_member(): void
+    {
+        $user1 = User::factory()->create();
+        $user2 = User::factory()->create();
+        $outsider = User::factory()->create();
+
+        $match = RoomMatch::create([
+            'user_id_1' => $user1->id,
+            'user_id_2' => $user2->id,
+            'user_1_status' => 'liked',
+            'user_2_status' => 'liked',
+            'matched_at' => now(),
+        ]);
+
+        $response = $this->actingAs($outsider)->post('/broadcasting/auth', [
+            'socket_id' => '1234.5678',
+            'channel_name' => "private-match.{$match->id}",
+        ]);
+
+        $response->assertStatus(403);
+    }
+}

--- a/tests/Feature/ErrorPagesTest.php
+++ b/tests/Feature/ErrorPagesTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Route;
+use Tests\TestCase;
+
+class ErrorPagesTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_custom_404_page_is_rendered(): void
+    {
+        $response = $this->get('/non-existent-page');
+
+        $response->assertStatus(404);
+        $response->assertSee('Página no encontrada');
+    }
+
+    public function test_custom_500_page_is_rendered(): void
+    {
+        Route::get('/force-error', function () {
+            abort(500);
+        });
+
+        config(['app.debug' => false]);
+
+        $response = $this->get('/force-error');
+
+        $response->assertStatus(500);
+        $response->assertSee('Error del servidor');
+    }
+}


### PR DESCRIPTION
## Summary
- cover rendering of custom `404` and `500` views
- test that broadcast channel authorization requires match membership

## Testing
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_684058324fc483298ae9560e8e459857