### PR TITLE
Add city autocomplete

### DIFF
--- a/app/Http/Controllers/ListingController.php
+++ b/app/Http/Controllers/ListingController.php
@@ -218,6 +218,24 @@ class ListingController extends Controller
     }
 
     /**
+     * Suggest city names for autocomplete.
+     */
+    public function citySuggestions(Request $request): JsonResponse
+    {
+        $term = $request->input('term');
+
+        $cities = \App\Models\Listing::query()
+            ->select('city')
+            ->when($term, fn($q) => $q->where('city', 'like', "%{$term}%"))
+            ->distinct()
+            ->orderBy('city')
+            ->limit(10)
+            ->pluck('city');
+
+        return response()->json($cities);
+    }
+
+    /**
      * Get listing statistics (AJAX).
      */
     public function statistics(): JsonResponse

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -79,4 +79,33 @@ document.addEventListener('DOMContentLoaded', () => {
             if (maxEl) maxEl.textContent = Math.round(values[1]);
         });
     }
+
+    const cityInput = document.querySelector('input[name="city"]');
+    const cityList = document.getElementById('city-suggestions');
+    if (cityInput && cityList) {
+        let cancelToken;
+        cityInput.addEventListener('input', () => {
+            const term = cityInput.value.trim();
+            if (term.length < 2) {
+                cityList.innerHTML = '';
+                return;
+            }
+            if (cancelToken) cancelToken.cancel();
+            cancelToken = axios.CancelToken.source();
+            axios.get('/api/cities', {
+                params: { term },
+                cancelToken: cancelToken.token,
+                headers
+            }).then(response => {
+                cityList.innerHTML = '';
+                response.data.forEach(city => {
+                    const option = document.createElement('option');
+                    option.value = city;
+                    cityList.appendChild(option);
+                });
+            }).catch(error => {
+                if (!axios.isCancel(error)) console.error(error);
+            });
+        });
+    }
 });

--- a/resources/views/listings/index.blade.php
+++ b/resources/views/listings/index.blade.php
@@ -14,7 +14,8 @@
         </div>
         <div class="col-md-4">
             <label class="form-label">Ciudad</label>
-            <input type="text" name="city" value="{{ request('city') }}" class="form-control" placeholder="Ciudad">
+            <input type="text" name="city" value="{{ request('city') }}" class="form-control" placeholder="Ciudad" list="city-suggestions" autocomplete="off">
+            <datalist id="city-suggestions"></datalist>
         </div>
         <div class="col-md-4">
             <label class="form-label">Precio (€)</label>

--- a/routes/web.php
+++ b/routes/web.php
@@ -128,6 +128,10 @@ Route::get('/api/events/recommended', [EventController::class, 'recommended'])
     ->middleware('auth')
     ->name('api.events.recommended');
 
+// Sugerencias de ciudades para autocompletar
+Route::get('/api/cities', [ListingController::class, 'citySuggestions'])
+    ->name('api.cities');
+
 // Rutas de administración
 Route::middleware(['auth', 'admin'])->prefix('admin')->name('admin.')->group(function () {
     Route::get('/', function () {


### PR DESCRIPTION
## Summary
- provide a route that returns city name suggestions
- include datalist autocomplete input on listing search
- fetch city suggestions in app.js as user types

## Testing
- `vendor/bin/phpunit` *(fails: The /workspace/JAL/bootstrap/cache directory must be present and writable)*

------
https://chatgpt.com/codex/tasks/task_e_68405de9640c83299249d787a655ab43