### PR TITLE
Add infinite scroll for listings

### DIFF
--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -108,4 +108,36 @@ document.addEventListener('DOMContentLoaded', () => {
             });
         });
     }
+
+    const container = document.getElementById('listing-container');
+    const pagination = document.getElementById('pagination-links');
+    const sentinel = document.getElementById('load-more-sentinel');
+    if (container && pagination && sentinel) {
+        const observer = new IntersectionObserver(entries => {
+            if (entries.some(e => e.isIntersecting)) {
+                loadNextPage();
+            }
+        }, { rootMargin: '100px' });
+
+        observer.observe(sentinel);
+
+        async function loadNextPage() {
+            const nextLink = pagination.querySelector('a[rel="next"]');
+            if (!nextLink) {
+                observer.disconnect();
+                return;
+            }
+
+            const url = new URL(nextLink.href);
+            url.pathname = '/api/listings/cards';
+
+            try {
+                const response = await axios.get(url.toString(), { headers });
+                container.insertAdjacentHTML('beforeend', response.data.html);
+                pagination.innerHTML = response.data.links;
+            } catch (error) {
+                console.error(error);
+            }
+        }
+    }
 });

--- a/resources/views/listings/index.blade.php
+++ b/resources/views/listings/index.blade.php
@@ -31,25 +31,12 @@
         </div>
     </form>
 
-    <div class="row">
-        @foreach($listings as $listing)
-            <div class="col-md-4 mb-4">
-                <div class="card h-100">
-                    @if($listing->first_image_url)
-                        <img src="{{ $listing->first_image_url }}" class="card-img-top" alt="Imagen del piso">
-                    @endif
-                    <div class="card-body">
-                        <h5 class="card-title">{{ $listing->title }}</h5>
-                        <p class="card-text">{{ $listing->city }} - {{ $listing->formatted_price }}</p>
-                        <p class="card-text">
-                            {!! $listing->occupant_icons !!}
-                        </p>
-                        <a href="{{ route('listings.show', $listing) }}" class="btn btn-sm btn-outline-primary">Ver más</a>
-                    </div>
-                </div>
-            </div>
-        @endforeach
+    <div id="listing-container" class="row">
+        @include('listings.partials.cards', ['listings' => $listings])
     </div>
-    {{ $listings->appends(request()->query())->links() }}
+    <div id="pagination-links" class="d-none">
+        {{ $listings->appends(request()->query())->links() }}
+    </div>
+    <div id="load-more-sentinel"></div>
 </div>
 @endsection

--- a/resources/views/listings/partials/cards.blade.php
+++ b/resources/views/listings/partials/cards.blade.php
@@ -1,0 +1,17 @@
+@foreach($listings as $listing)
+    <div class="col-md-4 mb-4">
+        <div class="card h-100">
+            @if($listing->first_image_url)
+                <img src="{{ $listing->first_image_url }}" class="card-img-top" alt="Imagen del piso">
+            @endif
+            <div class="card-body">
+                <h5 class="card-title">{{ $listing->title }}</h5>
+                <p class="card-text">{{ $listing->city }} - {{ $listing->formatted_price }}</p>
+                <p class="card-text">
+                    {!! $listing->occupant_icons !!}
+                </p>
+                <a href="{{ route('listings.show', $listing) }}" class="btn btn-sm btn-outline-primary">Ver más</a>
+            </div>
+        </div>
+    </div>
+@endforeach

--- a/routes/web.php
+++ b/routes/web.php
@@ -122,6 +122,8 @@ Route::middleware(['auth'])->group(function () {
 // Rutas AJAX para estadísticas
 Route::get('/api/listings/statistics', [ListingController::class, 'statistics'])
     ->name('api.listings.statistics');
+Route::get('/api/listings/cards', [ListingController::class, 'cards'])
+    ->name('api.listings.cards');
 Route::get('/api/events/statistics', [EventController::class, 'statistics'])
     ->name('api.events.statistics');
 Route::get('/api/events/recommended', [EventController::class, 'recommended'])


### PR DESCRIPTION
## Summary
- provide listing card partials
- return paginated cards via new `/api/listings/cards` route
- update listings index to use the new partial and infinite scroll markup
- load more cards with IntersectionObserver in app.js

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68405f10f23083299405b917e7f1825f