### PR TITLE
Add theme toggle with persistence

### DIFF
--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -13,15 +13,25 @@ document.addEventListener('DOMContentLoaded', () => {
     };
 
     const htmlEl = document.documentElement;
-    const storedTheme = localStorage.getItem('theme');
-    if (storedTheme) htmlEl.setAttribute('data-bs-theme', storedTheme);
-
     const themeToggle = document.getElementById('theme-toggle');
+    const toggleIcon = themeToggle?.querySelector('i');
+
+    function setIcon(theme) {
+        if (!toggleIcon) return;
+        toggleIcon.classList.toggle('bi-moon-fill', theme === 'light');
+        toggleIcon.classList.toggle('bi-sun-fill', theme === 'dark');
+    }
+
+    const storedTheme = localStorage.getItem('theme') || 'light';
+    htmlEl.setAttribute('data-bs-theme', storedTheme);
+    setIcon(storedTheme);
+
     if (themeToggle) {
         themeToggle.addEventListener('click', () => {
             const newTheme = htmlEl.getAttribute('data-bs-theme') === 'dark' ? 'light' : 'dark';
             htmlEl.setAttribute('data-bs-theme', newTheme);
             localStorage.setItem('theme', newTheme);
+            setIcon(newTheme);
         });
     }
 

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -38,7 +38,7 @@
 
                     <ul class="navbar-nav ms-auto align-items-center mb-2 mb-md-0">
                         <li class="nav-item me-2">
-                            <button id="theme-toggle" type="button" class="btn btn-link nav-link px-2"><i class="bi bi-moon-fill"></i></button>
+                            <button id="theme-toggle" type="button" class="btn btn-link nav-link px-2" aria-label="Toggle theme"><i class="bi bi-moon-fill"></i></button>
                         </li>
                         @guest
                             @if (Route::has('login'))


### PR DESCRIPTION
## Summary
- add theme toggle icon behavior and persist selection in localStorage
- add aria-label on theme toggle button

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684061bf9940832998440534c6e85941