### PR TITLE
Add skeleton loader for listings

### DIFF
--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -122,6 +122,22 @@ document.addEventListener('DOMContentLoaded', () => {
     const container = document.getElementById('listing-container');
     const pagination = document.getElementById('pagination-links');
     const sentinel = document.getElementById('load-more-sentinel');
+    const skeletonTemplate = document.getElementById('skeleton-card-template');
+
+    function showSkeletons(count = 3) {
+        const skeletons = [];
+        if (!skeletonTemplate) return skeletons;
+        for (let i = 0; i < count; i++) {
+            const clone = skeletonTemplate.content.firstElementChild.cloneNode(true);
+            container.appendChild(clone);
+            skeletons.push(clone);
+        }
+        return skeletons;
+    }
+
+    function removeSkeletons(nodes) {
+        nodes.forEach(n => n.remove());
+    }
     if (container && pagination && sentinel) {
         const observer = new IntersectionObserver(entries => {
             if (entries.some(e => e.isIntersecting)) {
@@ -141,11 +157,14 @@ document.addEventListener('DOMContentLoaded', () => {
             const url = new URL(nextLink.href);
             url.pathname = '/api/listings/cards';
 
+            const skeletons = showSkeletons();
             try {
                 const response = await axios.get(url.toString(), { headers });
+                removeSkeletons(skeletons);
                 container.insertAdjacentHTML('beforeend', response.data.html);
                 pagination.innerHTML = response.data.links;
             } catch (error) {
+                removeSkeletons(skeletons);
                 console.error(error);
             }
         }

--- a/resources/sass/app.scss
+++ b/resources/sass/app.scss
@@ -2,3 +2,33 @@
 
 @import 'variables';
 @import 'bootstrap/scss/bootstrap';
+
+// Skeleton loading placeholders
+.skeleton-card {
+    .skeleton-image,
+    .skeleton-text {
+        animation: skeleton-loading 1.2s ease-in-out infinite;
+        background: #e0e0e0;
+        border-radius: .25rem;
+    }
+
+    .skeleton-image {
+        height: 180px;
+    }
+
+    .skeleton-text {
+        height: 1rem;
+    }
+}
+
+@keyframes skeleton-loading {
+    0% {
+        background-color: #e0e0e0;
+    }
+    50% {
+        background-color: #f0f0f0;
+    }
+    100% {
+        background-color: #e0e0e0;
+    }
+}

--- a/resources/views/listings/index.blade.php
+++ b/resources/views/listings/index.blade.php
@@ -34,6 +34,17 @@
     <div id="listing-container" class="row">
         @include('listings.partials.cards', ['listings' => $listings])
     </div>
+    <template id="skeleton-card-template">
+        <div class="col-md-4 mb-4 skeleton-placeholder">
+            <div class="card h-100 skeleton-card">
+                <div class="skeleton-image"></div>
+                <div class="card-body">
+                    <div class="skeleton-text mb-2 w-75"></div>
+                    <div class="skeleton-text w-50"></div>
+                </div>
+            </div>
+        </div>
+    </template>
     <div id="pagination-links" class="d-none">
         {{ $listings->appends(request()->query())->links() }}
     </div>


### PR DESCRIPTION
## Summary
- add SASS styles for skeleton cards
- include a skeleton card template in the listings page
- show skeleton placeholders while loading additional listings via AJAX

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68406018a5548329982761f824aa15ba