### PR TITLE
Add dark mode color variables

### DIFF
--- a/resources/sass/_variables.scss
+++ b/resources/sass/_variables.scss
@@ -5,3 +5,7 @@ $body-bg: #f8fafc;
 $font-family-sans-serif: 'Nunito', sans-serif;
 $font-size-base: 0.9rem;
 $line-height-base: 1.6;
+
+// Dark Mode
+$dark-body-bg: #121212;
+$dark-body-color: #f8f9fa;

--- a/resources/sass/app.scss
+++ b/resources/sass/app.scss
@@ -3,6 +3,12 @@
 @import 'variables';
 @import 'bootstrap/scss/bootstrap';
 
+// Dark mode styles using custom variables
+body.dark-mode {
+    background-color: $dark-body-bg;
+    color: $dark-body-color;
+}
+
 // Skeleton loading placeholders
 .skeleton-card {
     .skeleton-image,


### PR DESCRIPTION
## Summary
- define dark mode variables in `_variables.scss`
- apply them in `app.scss`
- compile assets so Bootstrap uses the new variables

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6840636361288329ab7349ea90164599