### PR TITLE
Update server error page

### DIFF
--- a/resources/views/errors/500.blade.php
+++ b/resources/views/errors/500.blade.php
@@ -2,8 +2,9 @@
 
 @section('content')
 <div class="container py-5 text-center">
-    <h1 class="display-4">Error del servidor</h1>
-    <p class="lead">Ha ocurrido un problema inesperado.</p>
+    <i class="bi bi-exclamation-triangle-fill display-1 text-warning"></i>
+    <h1 class="display-4 mt-4">Ups! Algo salió mal</h1>
+    <p class="lead">Nuestro equipo está trabajando para solucionarlo.</p>
     <a href="{{ url('/') }}" class="btn btn-primary mt-3">Volver al inicio</a>
 </div>
 @endsection

--- a/tests/Feature/ErrorPagesTest.php
+++ b/tests/Feature/ErrorPagesTest.php
@@ -29,6 +29,6 @@ class ErrorPagesTest extends TestCase
         $response = $this->get('/force-error');
 
         $response->assertStatus(500);
-        $response->assertSee('Error del servidor');
+        $response->assertSee('Ups! Algo salió mal');
     }
 }


### PR DESCRIPTION
## Summary
- update 500 error page with friendly text and warning icon
- update test expectations for new message

## Testing
- `php artisan test --testsuite Feature --filter ErrorPagesTest` *(fails: Composer install requires newer lock file format)*

------
https://chatgpt.com/codex/tasks/task_e_684064b60a488329a4f73d9084aa78fb