### PR TITLE
Add registration steps

### DIFF
--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -169,4 +169,52 @@ document.addEventListener('DOMContentLoaded', () => {
             }
         }
     }
+
+    const registerForm = document.getElementById('register-form');
+    if (registerForm) {
+        const steps = registerForm.querySelectorAll('.form-step');
+        const progressBar = document.getElementById('register-progress');
+        let currentStep = parseInt(registerForm.dataset.step || '0', 10);
+
+        function updateProgress() {
+            if (!progressBar) return;
+            const percent = ((currentStep + 1) / steps.length) * 100;
+            progressBar.style.width = `${percent}%`;
+        }
+
+        function showStep(index) {
+            steps.forEach((step, i) => {
+                step.classList.toggle('d-none', i !== index);
+            });
+            updateProgress();
+        }
+
+        registerForm.querySelectorAll('[data-next]').forEach(btn => {
+            btn.addEventListener('click', e => {
+                e.preventDefault();
+                const inputs = steps[currentStep].querySelectorAll('input, select');
+                for (const input of inputs) {
+                    if (!input.reportValidity()) {
+                        return;
+                    }
+                }
+                if (currentStep < steps.length - 1) {
+                    currentStep++;
+                    showStep(currentStep);
+                }
+            });
+        });
+
+        registerForm.querySelectorAll('[data-prev]').forEach(btn => {
+            btn.addEventListener('click', e => {
+                e.preventDefault();
+                if (currentStep > 0) {
+                    currentStep--;
+                    showStep(currentStep);
+                }
+            });
+        });
+
+        showStep(currentStep);
+    }
 });

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -5,45 +5,61 @@
     <div class="card shadow">
         <div class="card-header bg-primary text-white">{{ __('Register') }}</div>
         <div class="card-body">
-            <form method="POST" action="{{ route('register') }}">
+            @php
+                $step = ($errors->has('role') || $errors->has('password') || $errors->has('password_confirmation')) ? 1 : 0;
+            @endphp
+            <form method="POST" action="{{ route('register') }}" id="register-form" data-step="{{ $step }}">
                 @csrf
-                <div class="mb-3">
-                    <label for="name" class="form-label">{{ __('Name') }}</label>
-                    <input id="name" type="text" name="name" value="{{ old('name') }}" required autofocus class="form-control" autocomplete="name">
-                    @error('name')
-                        <div class="text-danger small">{{ $message }}</div>
-                    @enderror
+                <div class="progress mb-4">
+                    <div id="register-progress" class="progress-bar" style="width: 0%"></div>
                 </div>
-                <div class="mb-3">
-                    <label for="email" class="form-label">{{ __('Email Address') }}</label>
-                    <input id="email" type="email" name="email" value="{{ old('email') }}" required class="form-control" autocomplete="email">
-                    @error('email')
-                        <div class="text-danger small">{{ $message }}</div>
-                    @enderror
+
+                <div class="form-step">
+                    <div class="mb-3">
+                        <label for="name" class="form-label">{{ __('Name') }}</label>
+                        <input id="name" type="text" name="name" value="{{ old('name') }}" required autofocus class="form-control" autocomplete="name">
+                        @error('name')
+                            <div class="text-danger small">{{ $message }}</div>
+                        @enderror
+                    </div>
+                    <div class="mb-3">
+                        <label for="email" class="form-label">{{ __('Email Address') }}</label>
+                        <input id="email" type="email" name="email" value="{{ old('email') }}" required class="form-control" autocomplete="email">
+                        @error('email')
+                            <div class="text-danger small">{{ $message }}</div>
+                        @enderror
+                    </div>
+                    <div class="d-flex justify-content-end">
+                        <button class="btn btn-primary" data-next>{{ __('Next') }}</button>
+                    </div>
                 </div>
-                <div class="mb-3">
-                    <label for="role" class="form-label">{{ __('Register As') }}</label>
-                    <select id="role" name="role" required class="form-select">
-                        <option value="student" {{ old('role') == 'student' ? 'selected' : '' }}>Estudiante</option>
-                        <option value="owner" {{ old('role') == 'owner' ? 'selected' : '' }}>Propietario</option>
-                    </select>
-                    @error('role')
-                        <div class="text-danger small">{{ $message }}</div>
-                    @enderror
-                </div>
-                <div class="mb-3">
-                    <label for="password" class="form-label">{{ __('Password') }}</label>
-                    <input id="password" type="password" name="password" required class="form-control" autocomplete="new-password">
-                    @error('password')
-                        <div class="text-danger small">{{ $message }}</div>
-                    @enderror
-                </div>
-                <div class="mb-3">
-                    <label for="password-confirm" class="form-label">{{ __('Confirm Password') }}</label>
-                    <input id="password-confirm" type="password" name="password_confirmation" required class="form-control" autocomplete="new-password">
-                </div>
-                <div class="d-grid">
-                    <button type="submit" class="btn btn-primary">{{ __('Register') }}</button>
+
+                <div class="form-step d-none">
+                    <div class="mb-3">
+                        <label for="role" class="form-label">{{ __('Register As') }}</label>
+                        <select id="role" name="role" required class="form-select">
+                            <option value="student" {{ old('role') == 'student' ? 'selected' : '' }}>Estudiante</option>
+                            <option value="owner" {{ old('role') == 'owner' ? 'selected' : '' }}>Propietario</option>
+                        </select>
+                        @error('role')
+                            <div class="text-danger small">{{ $message }}</div>
+                        @enderror
+                    </div>
+                    <div class="mb-3">
+                        <label for="password" class="form-label">{{ __('Password') }}</label>
+                        <input id="password" type="password" name="password" required class="form-control" autocomplete="new-password">
+                        @error('password')
+                            <div class="text-danger small">{{ $message }}</div>
+                        @enderror
+                    </div>
+                    <div class="mb-3">
+                        <label for="password-confirm" class="form-label">{{ __('Confirm Password') }}</label>
+                        <input id="password-confirm" type="password" name="password_confirmation" required class="form-control" autocomplete="new-password">
+                    </div>
+                    <div class="d-flex justify-content-between">
+                        <button class="btn btn-secondary" data-prev>{{ __('Back') }}</button>
+                        <button type="submit" class="btn btn-primary">{{ __('Register') }}</button>
+                    </div>
                 </div>
             </form>
         </div>


### PR DESCRIPTION
## Summary
- add progress indicator and multi-step registration form
- handle step navigation and validation via app.js

## Testing
- `npm run build`
- `php artisan test` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684065b76e9c8329a52d12df7f170755