### PR TITLE
Add realtime chat with Pusher

### DIFF
--- a/app/Http/Controllers/RoomieMatchController.php
+++ b/app/Http/Controllers/RoomieMatchController.php
@@ -6,6 +6,7 @@ use Illuminate\Http\Request;
 use App\Services\RoomieMatchService;
 
 use App\Models\Message;
+use App\Models\RoomMatch;
 use App\Events\MessageSent;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Http\RedirectResponse;

--- a/resources/views/roomie/conversation.blade.php
+++ b/resources/views/roomie/conversation.blade.php
@@ -3,7 +3,7 @@
 @section('content')
 <div class="container py-4">
     <h2>Conversación</h2>
-<div id="messages" class="border rounded p-3 mb-3" style="height:300px; overflow-y:scroll;">
+<div id="messages" class="border rounded p-3 mb-3" style="height:300px; overflow-y:scroll;" data-match-id="{{ $match->id }}">
         @foreach($messages as $message)
             <div class="mb-2">
                 <strong>{{ $message->sender->name }}:</strong>


### PR DESCRIPTION
## Summary
- wire up Pusher with Laravel Echo
- stream conversation messages in real-time
- expose match id to the chat view
- import RoomMatch in controller

## Testing
- `npm exec --yes -- playwright install --with-deps` *(fails: apt installation incomplete)*
- `composer install --no-interaction` *(fails: command not found)*
- `vendor/bin/phpunit --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68406b00c4a0832997f6600409a3bbc2