### PR TITLE
Improve accessibility colors

### DIFF
--- a/resources/sass/_variables.scss
+++ b/resources/sass/_variables.scss
@@ -1,5 +1,7 @@
 // Body
 $body-bg: #f8fafc;
+$body-color: #212529;
+$link-color: #0b5ed7;
 
 // Typography
 $font-family-sans-serif: 'Nunito', sans-serif;
@@ -9,3 +11,4 @@ $line-height-base: 1.6;
 // Dark Mode
 $dark-body-bg: #121212;
 $dark-body-color: #f8f9fa;
+$dark-link-color: #82c5ff;

--- a/resources/sass/app.scss
+++ b/resources/sass/app.scss
@@ -4,9 +4,16 @@
 @import 'bootstrap/scss/bootstrap';
 
 // Dark mode styles using custom variables
+body {
+    color: $body-color;
+}
+
 body.dark-mode {
     background-color: $dark-body-bg;
     color: $dark-body-color;
+    a {
+        color: $dark-link-color;
+    }
 }
 
 // Skeleton loading placeholders


### PR DESCRIPTION
## Summary
- set accessible body and link colors in SASS variables
- apply new link color in dark mode styles

## Testing
- `npm run test:e2e` *(fails: navigation tests cannot connect to localhost)*

------
https://chatgpt.com/codex/tasks/task_e_68406d1bc3e48329a25882723a442a99