### PR TITLE
Add indexes on events category and date

### DIFF
--- a/database/migrations/2024_01_07_create_events_table.php
+++ b/database/migrations/2024_01_07_create_events_table.php
@@ -30,7 +30,9 @@ return new class extends Migration
 
             // Índices para optimización
             $table->index(['date', 'is_public']);
+            $table->index('date');
             $table->index(['category', 'is_public']);
+            $table->index('category');
             $table->index(['user_id']);
             $table->index(['place_id']);
         });

--- a/database/migrations/2025_06_05_040000_add_category_and_date_indexes_to_events_table.php
+++ b/database/migrations/2025_06_05_040000_add_category_and_date_indexes_to_events_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('events', function (Blueprint $table) {
+            if (Schema::hasColumn('events', 'category')) {
+                $table->index('category');
+            }
+            $table->index('date');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('events', function (Blueprint $table) {
+            if (Schema::hasColumn('events', 'category')) {
+                $table->dropIndex(['category']);
+            }
+            $table->dropIndex(['date']);
+        });
+    }
+};
+


### PR DESCRIPTION
## Summary
- index `category` and `date` fields in events table migration
- add new migration to backfill indexes for existing installations

## Testing
- `php artisan test` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68406f666ca083298d05c11fd2606850