### PR TITLE
Add Upcoming Event notification job

### DIFF
--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -6,6 +6,9 @@ use Illuminate\Console\Application as Artisan;
 use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Foundation\Console\Kernel as ConsoleKernel;
 use App\Console\Commands\NotifyEventAttendees;
+use App\Models\Event;
+use App\Notifications\UpcomingEventNotification;
+use Illuminate\Support\Carbon;
 
 class Kernel extends ConsoleKernel
 {
@@ -13,6 +16,17 @@ class Kernel extends ConsoleKernel
     {
         $schedule->command('events:notify-attendees')->daily();
         $schedule->command('listings:cleanup')->daily();
+        $schedule->call(function () {
+            $events = Event::with('attendees')
+                ->whereDate('date', Carbon::tomorrow()->toDateString())
+                ->get();
+
+            foreach ($events as $event) {
+                foreach ($event->attendees as $user) {
+                    $user->notify(new UpcomingEventNotification($event));
+                }
+            }
+        })->daily();
     }
 
     protected function commands(): void

--- a/app/Notifications/UpcomingEventNotification.php
+++ b/app/Notifications/UpcomingEventNotification.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Notifications;
+
+use App\Models\Event;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+
+class UpcomingEventNotification extends Notification implements ShouldQueue
+{
+    use Queueable;
+
+    protected Event $event;
+
+    public function __construct(Event $event)
+    {
+        $this->event = $event;
+    }
+
+    public function via(object $notifiable): array
+    {
+        return ['mail'];
+    }
+
+    public function toMail(object $notifiable): MailMessage
+    {
+        return (new MailMessage)
+            ->subject('Próximo evento: ' . $this->event->title)
+            ->line('El evento "' . $this->event->title . '" tendrá lugar pronto.')
+            ->action('Ver detalles', url('/events/' . $this->event->id))
+            ->line('Gracias por usar nuestra plataforma.');
+    }
+}


### PR DESCRIPTION
## Summary
- create `UpcomingEventNotification`
- schedule daily closure that emails attendees of tomorrow's events

## Testing
- `php artisan test` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684071e3c3648329b6e8ea8188bce494