### PR TITLE
Adjust listing statistics cache duration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -68,3 +68,4 @@ VITE_APP_NAME="${APP_NAME}" # Front-end app name
 GOOGLE_MAPS_API_KEY= # Google Maps API key for geocoding
 
 LISTING_CLEANUP_THRESHOLD_DAYS=60 # Days after available_from to clean up listings
+LISTING_STATISTICS_CACHE_TTL=86400 # Seconds to cache listing statistics

--- a/app/Services/ListingService.php
+++ b/app/Services/ListingService.php
@@ -258,7 +258,8 @@ class ListingService
 
     public function getListingStatistics(): array
     {
-        return Cache::remember('listing.statistics', 300, function () {
+        $ttl = config('listings.statistics_cache_ttl', 86400);
+        return Cache::remember('listing.statistics', $ttl, function () {
             $total = $this->listingRepository->getAll()->count();
             $available = $this->listingRepository->getAvailable()->count();
             $avgPrice = $this->listingRepository->getAvailable()->avg('price');

--- a/config/listings.php
+++ b/config/listings.php
@@ -2,4 +2,5 @@
 
 return [
     'cleanup_threshold_days' => env('LISTING_CLEANUP_THRESHOLD_DAYS', 60),
+    'statistics_cache_ttl' => env('LISTING_STATISTICS_CACHE_TTL', 86400),
 ];


### PR DESCRIPTION
## Summary
- control listing stats cache TTL with new `statistics_cache_ttl` setting
- document new env option

## Testing
- `php artisan test` *(fails: php not found)*

------
https://chatgpt.com/codex/tasks/task_e_68407368d88483298b643699d72e1c02