### PR TITLE
Add API docs with Swagger UI

### DIFF
--- a/docs/api.yaml
+++ b/docs/api.yaml
@@ -1,0 +1,203 @@
+openapi: 3.0.0
+info:
+  title: Spandam API
+  version: 1.0.0
+  description: API endpoints for listings and events.
+servers:
+  - url: /api
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: Token
+paths:
+  /login:
+    post:
+      summary: User login
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                email:
+                  type: string
+                password:
+                  type: string
+              required:
+                - email
+                - password
+      responses:
+        '200':
+          description: Authentication token
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  token:
+                    type: string
+        '401':
+          description: Invalid credentials
+  /logout:
+    post:
+      summary: User logout
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Logged out
+  /listings:
+    get:
+      summary: List listings
+      responses:
+        '200':
+          description: Paginated list of listings
+    post:
+      summary: Create listing
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                title:
+                  type: string
+                description:
+                  type: string
+              required:
+                - title
+                - description
+      responses:
+        '201':
+          description: Listing created
+  /listings/{id}:
+    get:
+      summary: View listing
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Single listing
+    put:
+      summary: Update listing
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                title:
+                  type: string
+                description:
+                  type: string
+      responses:
+        '200':
+          description: Listing updated
+    delete:
+      summary: Delete listing
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+      responses:
+        '204':
+          description: Listing deleted
+  /events:
+    get:
+      summary: List events
+      responses:
+        '200':
+          description: Paginated list of events
+    post:
+      summary: Create event
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                title:
+                  type: string
+                description:
+                  type: string
+              required:
+                - title
+                - description
+      responses:
+        '201':
+          description: Event created
+  /events/{id}:
+    get:
+      summary: View event
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Single event
+    put:
+      summary: Update event
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                title:
+                  type: string
+                description:
+                  type: string
+      responses:
+        '200':
+          description: Event updated
+    delete:
+      summary: Delete event
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+      responses:
+        '204':
+          description: Event deleted

--- a/resources/views/api-docs.blade.php
+++ b/resources/views/api-docs.blade.php
@@ -1,0 +1,18 @@
+@extends('layouts.app')
+
+@section('content')
+<link rel="stylesheet" href="https://unpkg.com/swagger-ui-dist/swagger-ui.css">
+<div class="container py-4">
+    <h1 class="mb-4">API Documentation</h1>
+    <div id="swagger-ui"></div>
+</div>
+<script src="https://unpkg.com/swagger-ui-dist/swagger-ui-bundle.js"></script>
+<script>
+    window.onload = () => {
+        SwaggerUIBundle({
+            url: "{{ url('/docs/api.yaml') }}",
+            dom_id: '#swagger-ui'
+        });
+    };
+</script>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -36,6 +36,15 @@ Route::get('/', function () {
     return view('welcome');
 })->name('home');
 
+// Documentación de la API con Swagger UI
+Route::get('/api/docs', function () {
+    return view('api-docs');
+})->name('api.docs');
+
+Route::get('/docs/api.yaml', function () {
+    return response()->file(base_path('docs/api.yaml'));
+})->name('api.docs.file');
+
 Route::get('/ocio', function () {
     $events = App\Models\Event::public()->upcoming()->get();
     $places = App\Models\Place::all();


### PR DESCRIPTION
## Summary
- add OpenAPI definition under `docs/api.yaml`
- show Swagger UI at `/api/docs`
- serve API spec file via new route

## Testing
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684073fab32c83298413203547987dbb