### PR TITLE
Add HTML sanitization to event requests

### DIFF
--- a/app/Http/Requests/StoreEventRequest.php
+++ b/app/Http/Requests/StoreEventRequest.php
@@ -109,5 +109,12 @@ class StoreEventRequest extends FormRequest
                 'price' => 0,
             ]);
         }
+
+        // Sanitize the description to avoid XSS
+        if ($this->has('description')) {
+            $this->merge([
+                'description' => strip_tags($this->input('description')),
+            ]);
+        }
     }
 }

--- a/app/Http/Requests/UpdateEventRequest.php
+++ b/app/Http/Requests/UpdateEventRequest.php
@@ -104,5 +104,12 @@ class UpdateEventRequest extends FormRequest
                 'price' => 0,
             ]);
         }
+
+        // Sanitize the description to avoid XSS
+        if ($this->has('description')) {
+            $this->merge([
+                'description' => strip_tags($this->input('description')),
+            ]);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- sanitize descriptions in StoreEventRequest
- sanitize descriptions in UpdateEventRequest

## Testing
- `composer install --no-interaction --no-progress --ignore-platform-req=ext-dom --ignore-platform-req=ext-xml --ignore-platform-req=ext-xmlwriter --no-scripts`
- `vendor/bin/phpunit --colors=never` *(fails: bootstrap cache errors and others)*

------
https://chatgpt.com/codex/tasks/task_e_684079d69cdc8329a77617a4c4e55269