### PR TITLE
Add event tags model and migrations

### DIFF
--- a/app/Models/Event.php
+++ b/app/Models/Event.php
@@ -64,6 +64,14 @@ class Event extends Model
     }
 
     /**
+     * Tags associated with the event.
+     */
+    public function tags()
+    {
+        return $this->belongsToMany(Tag::class)->withTimestamps();
+    }
+
+    /**
      * Users attending this event.
      */
     public function attendees()

--- a/app/Models/Tag.php
+++ b/app/Models/Tag.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Tag extends Model
+{
+    use HasFactory;
+
+    protected $fillable = ['name'];
+
+    public function events()
+    {
+        return $this->belongsToMany(Event::class)->withTimestamps();
+    }
+}

--- a/database/migrations/2025_06_06_000000_create_tags_table.php
+++ b/database/migrations/2025_06_06_000000_create_tags_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('tags', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('tags');
+    }
+};

--- a/database/migrations/2025_06_06_010000_create_event_tag_table.php
+++ b/database/migrations/2025_06_06_010000_create_event_tag_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('event_tag', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('event_id')->constrained()->onDelete('cascade');
+            $table->foreignId('tag_id')->constrained()->onDelete('cascade');
+            $table->timestamps();
+            $table->unique(['event_id', 'tag_id']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('event_tag');
+    }
+};

--- a/tests/Feature/EventTest.php
+++ b/tests/Feature/EventTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature;
 
 use App\Models\Event;
 use App\Models\User;
+use App\Models\Tag;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Hash;
@@ -128,5 +129,26 @@ class EventTest extends TestCase
             'user_id' => $attendee->id,
         ]);
         $this->assertEquals(1, $event->fresh()->current_attendees);
+    }
+
+    public function test_event_can_have_multiple_tags(): void
+    {
+        $user = $this->createUser();
+        $tag1 = Tag::create(['name' => 'Music']);
+        $tag2 = Tag::create(['name' => 'Outdoor']);
+
+        $event = Event::create([
+            'title' => 'Tagged Event',
+            'description' => 'desc',
+            'date' => Carbon::now()->addDay(),
+            'category' => 'social',
+            'user_id' => $user->id,
+        ]);
+
+        $event->tags()->attach([$tag1->id, $tag2->id]);
+
+        $this->assertCount(2, $event->tags);
+        $this->assertTrue($event->tags->contains($tag1));
+        $this->assertTrue($event->tags->contains($tag2));
     }
 }


### PR DESCRIPTION
## Summary
- create `Tag` model
- add tags and event_tag migrations
- support tags relationship in Event model
- cover tagging in feature test

## Testing
- `vendor/bin/phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68407ccf04208329a8b9431e1e8ee9a5