### PR TITLE
Add radius slider on listings search

### DIFF
--- a/app/Http/Controllers/ListingController.php
+++ b/app/Http/Controllers/ListingController.php
@@ -28,8 +28,12 @@ class ListingController extends Controller
         $filters = $request->only([
             'city', 'type', 'min_price', 'max_price',
             'bedrooms', 'bathrooms', 'available_from', 'search',
-            'university', 'radius'
+            'university', 'radius', 'latitude', 'longitude'
         ]);
+
+        if (!isset($filters['radius'])) {
+            $filters['radius'] = 10;
+        }
 
         if ($request->filled('price_range')) {
             [$min, $max] = array_map('intval', explode(',', $request->input('price_range')));
@@ -56,8 +60,12 @@ class ListingController extends Controller
         $filters = $request->only([
             'city', 'type', 'min_price', 'max_price',
             'bedrooms', 'bathrooms', 'available_from', 'search',
-            'university', 'radius'
+            'university', 'radius', 'latitude', 'longitude'
         ]);
+
+        if (!isset($filters['radius'])) {
+            $filters['radius'] = 10;
+        }
 
         if ($request->filled('price_range')) {
             [$min, $max] = array_map('intval', explode(',', $request->input('price_range')));

--- a/resources/views/listings/index.blade.php
+++ b/resources/views/listings/index.blade.php
@@ -26,6 +26,13 @@
             </div>
             <input type="hidden" name="price_range" id="price_range" value="{{ request('price_range', '0,2000') }}">
         </div>
+        <div class="col-md-4">
+            <label class="form-label">Radio de búsqueda (km)</label>
+            <input type="range" class="form-range" min="1" max="50" name="radius" id="radius" value="{{ request('radius', 10) }}" oninput="radiusOutput.value = this.value">
+            <div class="text-end small">
+                <output id="radiusOutput">{{ request('radius', 10) }}</output> km
+            </div>
+        </div>
         <div class="col-md-4 d-flex align-items-end">
             <button type="submit" class="btn btn-primary w-100">Filtrar</button>
         </div>


### PR DESCRIPTION
## Summary
- include latitude and longitude filters when listing search is requested
- default missing radius parameter to 10
- add a radius slider to the listings filter form

## Testing
- `npx playwright test` *(fails: playwright not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68407eb013f083299321670885225f1e