### PR TITLE
Add interactive map for listing creation

### DIFF
--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -278,8 +278,50 @@ document.addEventListener('DOMContentLoaded', () => {
             });
         };
 
+
         if (window.google && window.google.maps) {
             window.initEventMap();
+        }
+    }
+
+    const listingMapEl = document.getElementById('listing-map');
+    if (listingMapEl) {
+        window.initListingMap = function () {
+            const center = JSON.parse(listingMapEl.dataset.center);
+            const zoom = parseInt(listingMapEl.dataset.zoom, 10);
+            const latInput = document.querySelector('input[name="latitude"]');
+            const lngInput = document.querySelector('input[name="longitude"]');
+            const startLat = parseFloat(latInput.value) || center.lat;
+            const startLng = parseFloat(lngInput.value) || center.lng;
+            const map = new google.maps.Map(listingMapEl, {
+                center: { lat: startLat, lng: startLng },
+                zoom
+            });
+
+            let marker;
+
+            function setMarker(latLng) {
+                if (!marker) {
+                    marker = new google.maps.Marker({ position: latLng, map });
+                } else {
+                    marker.setPosition(latLng);
+                }
+            }
+
+            map.addListener('click', e => {
+                setMarker(e.latLng);
+                if (latInput) latInput.value = e.latLng.lat();
+                if (lngInput) lngInput.value = e.latLng.lng();
+            });
+
+            if (latInput.value && lngInput.value) {
+                const pos = new google.maps.LatLng(startLat, startLng);
+                setMarker(pos);
+            }
+        };
+
+        if (window.google && window.google.maps) {
+            window.initListingMap();
         }
     }
 

--- a/resources/views/listings/create.blade.php
+++ b/resources/views/listings/create.blade.php
@@ -67,6 +67,15 @@
             <label class="form-label">Disponible desde</label>
             <input type="date" name="available_from" value="{{ old('available_from') }}" class="form-control" required>
         </div>
+
+        <div class="mb-3">
+            <label class="form-label">Ubicación en el mapa</label>
+            <div id="listing-map" style="height: 300px"
+                 data-center='@json(config('services.google_maps.default_center'))'
+                 data-zoom='{{ config('services.google_maps.default_zoom') }}'></div>
+            <div class="form-text">Haz clic en el mapa para colocar el marcador.</div>
+        </div>
+
         <div class="mb-3">
             <label class="form-label">Latitud</label>
             <input type="number" step="0.000001" name="latitude" value="{{ old('latitude') }}" class="form-control">
@@ -82,4 +91,5 @@
         <button type="submit" class="btn btn-primary">Guardar</button>
     </form>
 </div>
+<script src="https://maps.googleapis.com/maps/api/js?key={{ config('services.google_maps.api_key') }}&callback=initListingMap" async defer></script>
 @endsection


### PR DESCRIPTION
## Summary
- enable selecting latitude/longitude by dropping a pin on Google Maps
- initialize the map in `app.js`
- add Google Maps script and container to listing creation view

## Testing
- `php artisan test` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6840820f7184832986363d56a27bf276