### PR TITLE
Log failed login attempts

### DIFF
--- a/app/Http/Controllers/Auth/LoginController.php
+++ b/app/Http/Controllers/Auth/LoginController.php
@@ -7,6 +7,8 @@ use Illuminate\Foundation\Auth\AuthenticatesUsers;
 use Illuminate\Http\Request;
 use Laravel\Fortify\Actions\RedirectIfTwoFactorAuthenticatable;
 use App\Providers\RouteServiceProvider;
+use Illuminate\Validation\ValidationException;
+use App\Models\LoginAttempt;
 
 class LoginController extends Controller
 {
@@ -51,5 +53,19 @@ class LoginController extends Controller
             ->handle($request, function () {
                 return redirect()->intended($this->redirectPath());
             });
+    }
+
+    /**
+     * Handle a failed authentication attempt.
+     */
+    protected function sendFailedLoginResponse(Request $request)
+    {
+        LoginAttempt::create([
+            'ip_address' => $request->ip(),
+        ]);
+
+        throw ValidationException::withMessages([
+            $this->username() => [trans('auth.failed')],
+        ]);
     }
 }

--- a/app/Models/LoginAttempt.php
+++ b/app/Models/LoginAttempt.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class LoginAttempt extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'ip_address',
+    ];
+}

--- a/database/migrations/2025_06_07_000000_create_login_attempts_table.php
+++ b/database/migrations/2025_06_07_000000_create_login_attempts_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('login_attempts', function (Blueprint $table) {
+            $table->id();
+            $table->string('ip_address', 45);
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('login_attempts');
+    }
+};


### PR DESCRIPTION
## Summary
- add LoginAttempt model
- log failed login attempts from LoginController
- store failures in `login_attempts` table

## Testing
- `php artisan test` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6840866411c083298692610f3ca4f2c7