### PR TITLE
Add CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: CI
+
+on:
+  push:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - run: composer install --no-interaction --prefer-dist --no-progress --no-scripts
+      - run: npm ci
+      - run: ./vendor/bin/phpunit
+      - run: npx playwright install --with-deps
+      - run: npm run test:e2e


### PR DESCRIPTION
## Summary
- add CI workflow to run composer install, npm ci, phpunit, and Playwright tests

## Testing
- `composer install --no-interaction --prefer-dist --no-scripts`
- `npm ci`
- `./vendor/bin/phpunit` *(fails: The /workspace/JAL/bootstrap/cache directory must be present and writable)*
- `npx playwright install --with-deps`
- `npm run test:e2e` *(fails: page.goto: net::ERR_CONNECTION_REFUSED)*

------
https://chatgpt.com/codex/tasks/task_e_68408cef6d48832997e9c72736e20fd6