### PR TITLE
Add composer lint script

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -57,6 +57,9 @@
         "dev": [
             "Composer\\Config::disableProcessTimeout",
             "npx concurrently -c \"#93c5fd,#c4b5fd,#fb7185,#fdba74\" \"php artisan serve\" \"php artisan queue:listen --tries=1\" \"php artisan pail --timeout=0\" \"npm run dev\" --names=server,queue,logs,vite"
+        ],
+        "lint": [
+            "vendor/bin/pint"
         ]
     },
     "extra": {


### PR DESCRIPTION
## Summary
- add `composer lint` script using Laravel Pint

## Testing
- `composer lint -- --test`
- `php artisan test` *(fails: Target ExceptionHandler is not instantiable)*

------
https://chatgpt.com/codex/tasks/task_e_6840cad326108329b75544123c974517