### PR TITLE
Add demo seeders

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,9 @@ Después de ejecutar los seeders, tendrás disponibles:
 - **Email**: maria@test.com | carlos@test.com | ana@test.com | david@test.com
 - **Password**: password
 
+### Datos de ejemplo
+- Se crean varios anuncios de alojamiento y eventos públicos para probar la aplicación en local.
+
 ## 📁 Estructura del Proyecto
 
 ```

--- a/database/seeders/CategorySeeder.php
+++ b/database/seeders/CategorySeeder.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Category;
+use Illuminate\Database\Seeder;
+
+class CategorySeeder extends Seeder
+{
+    public function run(): void
+    {
+        $categories = [
+            'Académico',
+            'Cultural',
+            'Deportivo',
+            'Social',
+            'Musical',
+            'Gastronómico',
+            'Tecnológico',
+            'Artístico',
+            'Voluntariado',
+        ];
+
+        foreach ($categories as $name) {
+            Category::firstOrCreate(['name' => $name]);
+        }
+
+        $this->command->info('Categorías creadas exitosamente.');
+    }
+}

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -13,8 +13,12 @@ class DatabaseSeeder extends Seeder
     {
         $this->call([
             AdminUserSeeder::class,
+            DemoUsersSeeder::class,
             AcademicInfoSeeder::class,
             PlacesSeeder::class,
+            CategorySeeder::class,
+            ListingSeeder::class,
+            EventSeeder::class,
         ]);
     }
 }

--- a/database/seeders/DemoUsersSeeder.php
+++ b/database/seeders/DemoUsersSeeder.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\User;
+use App\Models\Profile;
+use Illuminate\Database\Seeder;
+
+class DemoUsersSeeder extends Seeder
+{
+    public function run(): void
+    {
+        User::factory(5)
+            ->create()
+            ->each(function (User $user) {
+                $user->profile()->create(Profile::factory()->make()->toArray());
+            });
+
+        $this->command->info('Usuarios adicionales de prueba creados.');
+    }
+}

--- a/database/seeders/EventSeeder.php
+++ b/database/seeders/EventSeeder.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Event;
+use App\Models\User;
+use App\Models\Place;
+use App\Models\Category;
+use Illuminate\Database\Seeder;
+
+class EventSeeder extends Seeder
+{
+    public function run(): void
+    {
+        $user = User::first();
+        $place = Place::first();
+        $category = Category::first();
+
+        if (!$user || !$place || !$category) {
+            return;
+        }
+
+        $events = [
+            [
+                'title' => 'Fiesta de bienvenida',
+                'description' => 'Celebración para los nuevos estudiantes',
+                'date' => now()->addDays(7),
+                'time' => '21:00',
+                'place_id' => $place->id,
+                'user_id' => $user->id,
+                'category_id' => $category->id,
+                'is_public' => true,
+                'price' => 0,
+                'max_attendees' => 100,
+            ],
+            [
+                'title' => 'Torneo deportivo',
+                'description' => 'Competición amistosa en la universidad',
+                'date' => now()->addDays(14),
+                'time' => '10:00',
+                'place_id' => $place->id,
+                'user_id' => $user->id,
+                'category_id' => Category::where('name', 'Deportivo')->first()?->id ?? $category->id,
+                'is_public' => true,
+                'price' => 5.00,
+                'max_attendees' => 50,
+            ],
+            [
+                'title' => 'Concierto solidario',
+                'description' => 'Música en vivo para recaudar fondos',
+                'date' => now()->addDays(30),
+                'time' => '19:30',
+                'place_id' => $place->id,
+                'user_id' => $user->id,
+                'category_id' => Category::where('name', 'Musical')->first()?->id ?? $category->id,
+                'is_public' => true,
+                'price' => 10.00,
+                'max_attendees' => 200,
+            ],
+        ];
+
+        foreach ($events as $data) {
+            Event::firstOrCreate(
+                ['title' => $data['title'], 'date' => $data['date']],
+                $data
+            );
+        }
+
+        $this->command->info('Eventos de ejemplo creados.');
+    }
+}

--- a/database/seeders/ListingSeeder.php
+++ b/database/seeders/ListingSeeder.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Listing;
+use App\Models\User;
+use Illuminate\Database\Seeder;
+
+class ListingSeeder extends Seeder
+{
+    public function run(): void
+    {
+        $user = User::first();
+
+        if (!$user) {
+            return;
+        }
+
+        $listings = [
+            [
+                'title' => 'Piso luminoso en el centro',
+                'description' => 'Apartamento ideal para estudiantes, cercano a la universidad.',
+                'address' => 'Calle Mayor 1',
+                'city' => 'Valencia',
+                'zip_code' => '46001',
+                'price' => 750.00,
+                'type' => 'apartamento',
+                'square_meters' => 80,
+                'current_occupants' => 1,
+                'max_occupants' => 3,
+                'phone' => '600111222',
+                'bedrooms' => 3,
+                'bathrooms' => 1,
+                'available_from' => now()->addDays(5),
+                'is_available' => true,
+                'image_paths' => [],
+                'latitude' => 39.4702,
+                'longitude' => -0.3768,
+            ],
+            [
+                'title' => 'Habitación en piso compartido',
+                'description' => 'Se alquila habitación en piso tranquilo.',
+                'address' => 'Avenida de Aragón 25',
+                'city' => 'Valencia',
+                'zip_code' => '46021',
+                'price' => 300.00,
+                'type' => 'habitacion',
+                'square_meters' => 90,
+                'current_occupants' => 2,
+                'max_occupants' => 3,
+                'phone' => '600222333',
+                'bedrooms' => 1,
+                'bathrooms' => 1,
+                'available_from' => now()->addDays(15),
+                'is_available' => true,
+                'image_paths' => [],
+                'latitude' => 39.4699,
+                'longitude' => -0.3541,
+            ],
+            [
+                'title' => 'Estudio cerca de la playa',
+                'description' => 'Pequeño estudio totalmente equipado.',
+                'address' => 'Calle del Mar 5',
+                'city' => 'Valencia',
+                'zip_code' => '46011',
+                'price' => 500.00,
+                'type' => 'estudio',
+                'square_meters' => 40,
+                'current_occupants' => 0,
+                'max_occupants' => 1,
+                'phone' => '600333444',
+                'bedrooms' => 1,
+                'bathrooms' => 1,
+                'available_from' => now()->addDays(30),
+                'is_available' => true,
+                'image_paths' => [],
+                'latitude' => 39.4650,
+                'longitude' => -0.3300,
+            ],
+        ];
+
+        foreach ($listings as $data) {
+            Listing::firstOrCreate(
+                ['title' => $data['title'], 'address' => $data['address']],
+                array_merge($data, ['user_id' => $user->id])
+            );
+        }
+
+        $this->command->info('Anuncios de alojamiento creados.');
+    }
+}


### PR DESCRIPTION
## Summary
- seed demo categories, listings and events
- create additional fake users for local testing
- register new seeders in DatabaseSeeder
- note demo data in README

## Testing
- `php artisan test` *(fails: php not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840cc6bc52483299d6c1bd11196dc12