### PR TITLE
Add admin toggle tests

### DIFF
--- a/app/Http/Controllers/AdminController.php
+++ b/app/Http/Controllers/AdminController.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\User;
+use Illuminate\Http\RedirectResponse;
+
+class AdminController extends Controller
+{
+    public function toggleAdmin(User $user): RedirectResponse
+    {
+        $user->update(['is_admin' => !$user->is_admin]);
+
+        return back();
+    }
+
+    // Placeholder methods referenced in routes
+    public function users()
+    {
+        return view('admin.dashboard');
+    }
+
+    public function listings()
+    {
+        return view('admin.dashboard');
+    }
+
+    public function events()
+    {
+        return view('admin.dashboard');
+    }
+
+    public function places()
+    {
+        return view('admin.dashboard');
+    }
+
+    public function verifyPlace()
+    {
+        return back();
+    }
+}

--- a/resources/views/admin/dashboard.blade.php
+++ b/resources/views/admin/dashboard.blade.php
@@ -1,0 +1,1 @@
+<div>Admin Dashboard</div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -10,6 +10,7 @@ use App\Http\Controllers\DashboardController;
 use App\Http\Controllers\SubscriptionController;
 use App\Http\Controllers\FavoriteController;
 use App\Http\Controllers\Admin\CategoryController as AdminCategoryController;
+use App\Http\Controllers\AdminController;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Facades\App;
 

--- a/tests/Feature/AdminUserToggleTest.php
+++ b/tests/Feature/AdminUserToggleTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class AdminUserToggleTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_admin_can_toggle_user_admin_status(): void
+    {
+        $admin = User::factory()->create(['is_admin' => true]);
+        $user = User::factory()->create(['is_admin' => false]);
+
+        $response = $this->actingAs($admin)->patch("/admin/users/{$user->id}/toggle-admin");
+        $response->assertStatus(302);
+        $this->assertTrue($user->fresh()->is_admin);
+
+        $response = $this->actingAs($admin)->patch("/admin/users/{$user->id}/toggle-admin");
+        $response->assertStatus(302);
+        $this->assertFalse($user->fresh()->is_admin);
+    }
+
+    public function test_non_admin_cannot_toggle_user_admin_status(): void
+    {
+        $user = User::factory()->create(['is_admin' => false]);
+        $target = User::factory()->create(['is_admin' => false]);
+
+        $response = $this->actingAs($user)->patch("/admin/users/{$target->id}/toggle-admin");
+        $response->assertRedirect('/');
+        $this->assertFalse($target->fresh()->is_admin);
+    }
+
+    public function test_guest_is_redirected_to_login_when_toggling(): void
+    {
+        $user = User::factory()->create();
+
+        $response = $this->patch("/admin/users/{$user->id}/toggle-admin");
+        $response->assertRedirect('/login');
+        $this->assertFalse($user->fresh()->is_admin);
+    }
+}


### PR DESCRIPTION
## Summary
- add tests for toggling admin role
- provide minimal `AdminController` to support new route
- include admin dashboard placeholder
- register `AdminController` in routes

## Testing
- `phpunit --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840cdb43ff8832993cc5f08d6abe4f9