### PR TITLE
Add request metrics middleware

### DIFF
--- a/app/Http/Middleware/MetricsMiddleware.php
+++ b/app/Http/Middleware/MetricsMiddleware.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use App\Services\MetricsService;
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class MetricsMiddleware
+{
+    protected MetricsService $metricsService;
+
+    public function __construct(MetricsService $metricsService)
+    {
+        $this->metricsService = $metricsService;
+    }
+
+    public function handle(Request $request, Closure $next): Response
+    {
+        $start = microtime(true);
+        $startMemory = memory_get_usage();
+        $isError = false;
+        try {
+            /** @var Response $response */
+            $response = $next($request);
+            if ($response->getStatusCode() >= 500) {
+                $isError = true;
+            }
+        } catch (\Throwable $e) {
+            $isError = true;
+            throw $e;
+        } finally {
+            $duration = (microtime(true) - $start) * 1000;
+            $memoryUsage = memory_get_usage() - $startMemory;
+            $this->metricsService->record($request->path(), $duration, $memoryUsage, $isError);
+        }
+
+        return $response;
+    }
+}

--- a/app/Services/MetricsService.php
+++ b/app/Services/MetricsService.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Services;
+
+use Illuminate\Support\Facades\Log;
+
+class MetricsService
+{
+    public function record(string $path, float $durationMs, int $memoryUsage, bool $isError): void
+    {
+        Log::channel('metrics')->info('request_metrics', [
+            'path' => $path,
+            'duration_ms' => $durationMs,
+            'memory_usage_bytes' => $memoryUsage,
+            'error' => $isError,
+        ]);
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -22,6 +22,8 @@ return Application::configure(basePath: dirname(__DIR__))
             'role_or_permission' => \Spatie\Permission\Middleware\RoleOrPermissionMiddleware::class,
         ]);
 
+        $middleware->append(\App\Http\Middleware\MetricsMiddleware::class);
+
 
     })
     ->withProviders([

--- a/config/logging.php
+++ b/config/logging.php
@@ -118,6 +118,14 @@ return [
             'replace_placeholders' => true,
         ],
 
+        'metrics' => [
+            'driver' => 'daily',
+            'path' => storage_path('logs/metrics.log'),
+            'level' => 'info',
+            'days' => 7,
+            'replace_placeholders' => true,
+        ],
+
         'null' => [
             'driver' => 'monolog',
             'handler' => NullHandler::class,


### PR DESCRIPTION
## Summary
- add `MetricsMiddleware` and `MetricsService`
- log metrics through new `metrics` log channel
- register middleware in bootstrap config

## Testing
- `composer lint` *(fails: extension `xml` missing)*
- `php artisan test` *(fails: application could not bootstrap)*

------
https://chatgpt.com/codex/tasks/task_e_6840d14ec85883299350c3048b5f1eff