### PR TITLE
Add project setup scripts

### DIFF
--- a/scripts/setup.bat
+++ b/scripts/setup.bat
@@ -1,0 +1,10 @@
+@echo off
+rem Simple wrapper to run the setup script using Git Bash or WSL
+if exist "%ProgramFiles%\Git\bin\bash.exe" (
+    "%ProgramFiles%\Git\bin\bash.exe" "%~dp0setup.sh" %*
+) else if exist "C:\\Windows\\System32\\wsl.exe" (
+    wsl bash "%~dp0setup.sh" %*
+) else (
+    echo Please run scripts/setup.sh via a bash environment.
+    exit /b 1
+)

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -e
+
+# Simple environment setup script for the Laravel project
+
+check_command() {
+    if ! command -v "$1" >/dev/null 2>&1; then
+        echo "Error: $1 is not installed or not in PATH." >&2
+        exit 1
+    fi
+}
+
+check_command php
+check_command composer
+check_command node
+check_command npm
+
+# Install PHP and Node dependencies
+composer install
+npm install
+
+# Copy .env if it does not exist
+if [ ! -f .env ]; then
+    cp .env.example .env
+fi
+
+# Generate app key and run migrations
+php artisan key:generate
+php artisan migrate --seed
+
+# Build frontend assets
+npm run build
+
+# Optionally start the application if requested
+if [ "$1" = "start" ] || [ "$1" = "serve" ] || [ "$1" = "--start" ]; then
+    if grep -q "\"dev\"" composer.json >/dev/null 2>&1; then
+        composer dev
+    else
+        php artisan serve
+    fi
+fi


### PR DESCRIPTION
## Summary
- add `scripts/setup.sh` for installing dependencies, running migrations, building assets, and optionally starting the dev server
- add Windows wrapper `scripts/setup.bat`

## Testing
- `php artisan test` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840dac46964832991b0079d69857ac4