### PR TITLE
Fix composer install in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,10 @@ WORKDIR /var/www
 
 COPY . /var/www
 
-RUN cp .env.example .env && composer install --no-interaction --prefer-dist --no-progress
+RUN cp .env.example .env \
+    && php -r "file_put_contents('.env', preg_replace('/^APP_KEY=.*/m', 'APP_KEY=base64:'.base64_encode(random_bytes(32)), file_get_contents('.env')));" \
+    && touch database/database.sqlite \
+    && composer install --no-interaction --prefer-dist --no-progress
 
 EXPOSE 8000
 


### PR DESCRIPTION
## Summary
- ensure the application has a generated APP_KEY before running composer install
- create default sqlite database during the Docker image build

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6841cf6dd8348329b69623908eb3c77c